### PR TITLE
Remove the errors.e type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -142,11 +142,7 @@ func Wrap(cause error, message string) error {
 		return nil
 	}
 	pc, _, _, _ := runtime.Caller(1)
-	return &e{
-		cause:    cause,
-		message:  message,
-		location: location(pc),
-	}
+	return wrap(cause, message, pc)
 }
 
 // Wrapf returns an error annotating the cause with the format specifier.
@@ -156,9 +152,13 @@ func Wrapf(cause error, format string, args ...interface{}) error {
 		return nil
 	}
 	pc, _, _, _ := runtime.Caller(1)
+	return wrap(cause, fmt.Sprintf(format, args...), pc)
+}
+
+func wrap(err error, msg string, pc uintptr) error {
 	return &e{
-		cause:    cause,
-		message:  fmt.Sprintf(format, args...),
+		cause:    err,
+		message:  msg,
 		location: location(pc),
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -56,9 +56,11 @@ import (
 	"strings"
 )
 
-type loc uintptr
+// location represents a program counter that
+// implements the Location() method.
+type location uintptr
 
-func (l loc) Location() (string, int) {
+func (l location) Location() (string, int) {
 	pc := uintptr(l) - 1
 	fn := runtime.FuncForPC(pc)
 	if fn == nil {
@@ -112,17 +114,17 @@ func New(text string) error {
 	pc, _, _, _ := runtime.Caller(1)
 	return struct {
 		error
-		loc
+		location
 	}{
 		errors.New(text),
-		loc(pc),
+		location(pc),
 	}
 }
 
 type e struct {
 	cause   error
 	message string
-	loc
+	location
 }
 
 func (e *e) Error() string {
@@ -141,9 +143,9 @@ func Wrap(cause error, message string) error {
 	}
 	pc, _, _, _ := runtime.Caller(1)
 	return &e{
-		cause:   cause,
-		message: message,
-		loc:     loc(pc),
+		cause:    cause,
+		message:  message,
+		location: location(pc),
 	}
 }
 
@@ -155,9 +157,9 @@ func Wrapf(cause error, format string, args ...interface{}) error {
 	}
 	pc, _, _, _ := runtime.Caller(1)
 	return &e{
-		cause:   cause,
-		message: fmt.Sprintf(format, args...),
-		loc:     loc(pc),
+		cause:    cause,
+		message:  fmt.Sprintf(format, args...),
+		location: location(pc),
 	}
 }
 

--- a/errors.go
+++ b/errors.go
@@ -189,10 +189,6 @@ func Cause(err error) error {
 	return err
 }
 
-type locationer interface {
-	Location() (string, int)
-}
-
 // Print prints the error to Stderr.
 // If the error implements the Causer interface described in Cause
 // Print will recurse into the error's cause.
@@ -211,10 +207,13 @@ func Print(err error) {
 // The format of the output is the same as Print.
 // If err is nil, nothing is printed.
 func Fprint(w io.Writer, err error) {
+	type location interface {
+		Location() (string, int)
+	}
+
 	for err != nil {
-		location, ok := err.(locationer)
-		if ok {
-			file, line := location.Location()
+		if err, ok := err.(location); ok {
+			file, line := err.Location()
 			fmt.Fprintf(w, "%s:%d: ", file, line)
 		}
 		switch err := err.(type) {


### PR DESCRIPTION
Remove the errors.e type to make it impossible to type assert an error returned from Wrap{,f} or New.

Instead add behaviours to extract the Cause and the Message and use those in {F,}Print rather than hard coding the magic error.e type.

Also, these helper methods inline, so come at no cost.