### PR TITLE
Remove errors.Print

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -51,7 +51,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"runtime"
 	"strings"
 )
@@ -202,7 +201,7 @@ func Cause(err error) error {
 	return err
 }
 
-// Print prints the error to Stderr.
+// Fprint prints the error to the supplied writer.
 // If the error implements the Causer interface described in Cause
 // Print will recurse into the error's cause.
 // If the error implements the inteface:
@@ -212,12 +211,6 @@ func Cause(err error) error {
 //     }
 //
 // Print will also print the file and line of the error.
-func Print(err error) {
-	Fprint(os.Stderr, err)
-}
-
-// Fprint prints the error to the supplied writer.
-// The format of the output is the same as Print.
 // If err is nil, nothing is printed.
 func Fprint(w io.Writer, err error) {
 	type location interface {


### PR DESCRIPTION
errors.Print had a number of problems. Firstly, it was hard coded to
print to os.Stderr, which made it difficult to test, and hard to write
an example test for. Secondly, comments made in issue #20 make it clear
that helpers need to have a high bar for inclusion in this package, and
something that wrapped errors.Fprint in a way that was hard to test
fails that bar.

So, Remove errors.Print, which frees the identifier for being reused
later, and reduces the size of the package.