### PR TITLE
Reimplement Fprint in terms of fmt.Fprintf

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -57,13 +57,6 @@ type nilError struct{}
 
 func (nilError) Error() string { return "nil error" }
 
-type causeError struct {
-	cause error
-}
-
-func (e *causeError) Error() string { return "cause error" }
-func (e *causeError) Cause() error  { return e.cause }
-
 func TestCause(t *testing.T) {
 	x := New("error")
 	tests := []struct {
@@ -87,7 +80,7 @@ func TestCause(t *testing.T) {
 		want: io.EOF,
 	}, {
 		// caused error returns cause
-		err:  &causeError{cause: io.EOF},
+		err:  Wrap(io.EOF, "ignored"),
 		want: io.EOF,
 	}, {
 		err:  x, // return from errors.New
@@ -118,30 +111,29 @@ func TestFprintError(t *testing.T) {
 		err:  io.EOF,
 		want: "EOF\n",
 	}, {
-		// caused error returns cause
-		err: &causeError{cause: io.EOF},
+		err: Wrap(io.EOF, "cause error"),
 		want: "EOF\n" +
-			"cause error\n",
+			"github.com/pkg/errors/errors_test.go:114: cause error\n",
 	}, {
 		err:  x, // return from errors.New
-		want: "github.com/pkg/errors/errors_test.go:106: error\n",
+		want: "github.com/pkg/errors/errors_test.go:99: error\n",
 	}, {
 		err: Wrap(x, "message"),
-		want: "github.com/pkg/errors/errors_test.go:106: error\n" +
-			"github.com/pkg/errors/errors_test.go:129: message\n",
+		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
+			"github.com/pkg/errors/errors_test.go:121: message\n",
 	}, {
 		err: Wrap(io.EOF, "message"),
 		want: "EOF\n" +
-			"github.com/pkg/errors/errors_test.go:133: message\n",
+			"github.com/pkg/errors/errors_test.go:125: message\n",
 	}, {
 		err: Wrap(Wrap(x, "message"), "another message"),
-		want: "github.com/pkg/errors/errors_test.go:106: error\n" +
-			"github.com/pkg/errors/errors_test.go:137: message\n" +
-			"github.com/pkg/errors/errors_test.go:137: another message\n",
+		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
+			"github.com/pkg/errors/errors_test.go:129: message\n" +
+			"github.com/pkg/errors/errors_test.go:129: another message\n",
 	}, {
 		err: Wrapf(x, "message"),
-		want: "github.com/pkg/errors/errors_test.go:106: error\n" +
-			"github.com/pkg/errors/errors_test.go:142: message\n",
+		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
+			"github.com/pkg/errors/errors_test.go:134: message\n",
 	}}
 
 	for i, tt := range tests {

--- a/format_test.go
+++ b/format_test.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ func TestFormat(t *testing.T) {
 	}, {
 		New("error"),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:23: error",
+		"github.com/pkg/errors/format_test.go:24: error",
 	}, {
 		Errorf("%s", "error"),
 		"%s",
@@ -34,7 +35,7 @@ func TestFormat(t *testing.T) {
 	}, {
 		Errorf("%s", "error"),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:35: error",
+		"github.com/pkg/errors/format_test.go:36: error",
 	}, {
 		Wrap(New("error"), "error2"),
 		"%s",
@@ -46,11 +47,25 @@ func TestFormat(t *testing.T) {
 	}, {
 		Wrap(New("error"), "error2"),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:47: error2",
+		"github.com/pkg/errors/format_test.go:48: error\n" +
+			"github.com/pkg/errors/format_test.go:48: error2",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%s",
+		"error: EOF",
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%s",
 		"error2: error",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%v",
+		"error: EOF",
+	}, {
+		Wrap(io.EOF, "error"),
+		"%+v",
+		"EOF\n" +
+			"github.com/pkg/errors/format_test.go:65: error",
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%v",
@@ -58,7 +73,8 @@ func TestFormat(t *testing.T) {
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:59: error2",
+		"github.com/pkg/errors/format_test.go:74: error\n" +
+			"github.com/pkg/errors/format_test.go:74: error2",
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR follows on from #40 completely implementing Fprint in terms of
fmt.Fprintf. This will be the final PR before Fprint is removed.