### PR TITLE
Remove Fprint

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -180,17 +180,3 @@ func Cause(err error) error {
 	}
 	return err
 }
-
-// Fprint prints the error to the supplied writer.
-// If the error implements the Causer interface described in Cause
-// Fprint will recurse into the error's cause.
-// Fprint will also print the file and line of the error.
-// If err is nil, nothing is printed.
-//
-// Deprecated: Fprint will be removed in version 0.7.
-func Fprint(w io.Writer, err error) {
-	if err == nil {
-		return
-	}
-	fmt.Fprintf(w, "%+v\n", err)
-}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -91,57 +90,6 @@ func TestCause(t *testing.T) {
 		got := Cause(tt.err)
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
-		}
-	}
-}
-
-func TestFprintError(t *testing.T) {
-	x := New("error")
-	tests := []struct {
-		err  error
-		want string
-	}{{
-		// nil error is nil
-		err: nil,
-	}, {
-		// explicit nil error is nil
-		err: (error)(nil),
-	}, {
-		// uncaused error is unaffected
-		err:  io.EOF,
-		want: "EOF\n",
-	}, {
-		err: Wrap(io.EOF, "cause error"),
-		want: "EOF\n" +
-			"github.com/pkg/errors/errors_test.go:114: cause error\n",
-	}, {
-		err:  x, // return from errors.New
-		want: "github.com/pkg/errors/errors_test.go:99: error\n",
-	}, {
-		err: Wrap(x, "message"),
-		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
-			"github.com/pkg/errors/errors_test.go:121: message\n",
-	}, {
-		err: Wrap(io.EOF, "message"),
-		want: "EOF\n" +
-			"github.com/pkg/errors/errors_test.go:125: message\n",
-	}, {
-		err: Wrap(Wrap(x, "message"), "another message"),
-		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
-			"github.com/pkg/errors/errors_test.go:129: message\n" +
-			"github.com/pkg/errors/errors_test.go:129: another message\n",
-	}, {
-		err: Wrapf(x, "message"),
-		want: "github.com/pkg/errors/errors_test.go:99: error\n" +
-			"github.com/pkg/errors/errors_test.go:134: message\n",
-	}}
-
-	for i, tt := range tests {
-		var w bytes.Buffer
-		Fprint(&w, tt.err)
-		got := w.String()
-		if got != tt.want {
-			t.Errorf("test %d: Fprint(w, %q): got %q, want %q", i+1, tt.err, got, tt.want)
 		}
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -2,7 +2,6 @@ package errors_test
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 )
@@ -18,7 +17,7 @@ func ExampleNew_printf() {
 	err := errors.New("whoops")
 	fmt.Printf("%+v", err)
 
-	// Output: github.com/pkg/errors/example_test.go:18: whoops
+	// Output: github.com/pkg/errors/example_test.go:17: whoops
 }
 
 func ExampleWrap() {
@@ -45,14 +44,14 @@ func ExampleCause() {
 	// error
 }
 
-func ExampleFprint() {
+func ExampleCause_printf() {
 	err := fn()
-	errors.Fprint(os.Stdout, err)
+	fmt.Printf("%+v\n", err)
 
-	// Output: github.com/pkg/errors/example_test.go:33: error
-	// github.com/pkg/errors/example_test.go:34: inner
-	// github.com/pkg/errors/example_test.go:35: middle
-	// github.com/pkg/errors/example_test.go:36: outer
+	// Output: github.com/pkg/errors/example_test.go:32: error
+	// github.com/pkg/errors/example_test.go:33: inner
+	// github.com/pkg/errors/example_test.go:34: middle
+	// github.com/pkg/errors/example_test.go:35: outer
 }
 
 func ExampleWrapf() {
@@ -67,7 +66,7 @@ func ExampleErrorf() {
 	err := errors.Errorf("whoops: %s", "foo")
 	fmt.Printf("%+v", err)
 
-	// Output: github.com/pkg/errors/example_test.go:67: whoops: foo
+	// Output: github.com/pkg/errors/example_test.go:66: whoops: foo
 }
 
 func Example_stacktrace() {
@@ -83,5 +82,5 @@ func Example_stacktrace() {
 	st := err.Stacktrace()
 	fmt.Printf("%+v", st[0:2]) // top two frames
 
-	// Output: [github.com/pkg/errors/example_test.go:33 github.com/pkg/errors/example_test.go:78]
+	// Output: [github.com/pkg/errors/example_test.go:32 github.com/pkg/errors/example_test.go:77]
 }


### PR DESCRIPTION
This PR removes the `Fprint` wrapper and updates all examples to use `fmt.Printf`.