### PR TITLE
Introduce errors.Stacktrace

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -71,7 +71,7 @@ func ExampleErrorf() {
 
 func Example_stacktrace() {
 	type Stacktrace interface {
-		Stacktrace() []errors.Frame
+		Stacktrace() errors.Stacktrace
 	}
 
 	err, ok := errors.Cause(fn()).(Stacktrace)

--- a/stack.go
+++ b/stack.go
@@ -76,10 +76,27 @@ func (f Frame) Format(s fmt.State, verb rune) {
 	}
 }
 
+// Stacktrace is stack of Frames from innermost (newest) to outermost (oldest).
+type Stacktrace []Frame
+
+func (st Stacktrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			fmt.Fprintf(s, "%+v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
 // stack represents a stack of program counters.
 type stack []uintptr
 
-func (s *stack) Stacktrace() []Frame {
+func (s *stack) Stacktrace() Stacktrace {
 	f := make([]Frame, len(*s))
 	for i := 0; i < len(f); i++ {
 		f[i] = Frame((*s)[i])

--- a/stack.go
+++ b/stack.go
@@ -85,6 +85,8 @@ func (st Stacktrace) Format(s fmt.State, verb rune) {
 		switch {
 		case s.Flag('+'):
 			fmt.Fprintf(s, "%+v", []Frame(st))
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
 		default:
 			fmt.Fprintf(s, "%v", []Frame(st))
 		}

--- a/stack_test.go
+++ b/stack_test.go
@@ -250,6 +250,10 @@ func TestStacktraceFormat(t *testing.T) {
 		"%+v",
 		"[]",
 	}, {
+		nil,
+		"%#v",
+		"[]errors.Frame(nil)",
+	}, {
 		make(Stacktrace, 0),
 		"%s",
 		"[]",
@@ -261,6 +265,10 @@ func TestStacktraceFormat(t *testing.T) {
 		make(Stacktrace, 0),
 		"%+v",
 		"[]",
+	}, {
+		make(Stacktrace, 0),
+		"%#v",
+		"[]errors.Frame{}",
 	}, {
 		stacktrace()[:2],
 		"%s",
@@ -268,11 +276,15 @@ func TestStacktraceFormat(t *testing.T) {
 	}, {
 		stacktrace()[:2],
 		"%v",
-		"[stack_test.go:230 stack_test.go:269]",
+		"[stack_test.go:230 stack_test.go:277]",
 	}, {
 		stacktrace()[:2],
 		"%+v",
-		"[github.com/pkg/errors/stack_test.go:230 github.com/pkg/errors/stack_test.go:273]",
+		"[github.com/pkg/errors/stack_test.go:230 github.com/pkg/errors/stack_test.go:281]",
+	}, {
+		stacktrace()[:2],
+		"%#v",
+		"[]errors.Frame{stack_test.go:230, stack_test.go:285}",
 	}}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Introduce a new type to replace the unnamed return value from
`Stacktrace()`. `Stacktrace` implements `fmt.Formatter` and currently
replicates the default behaviour of printing a `[]Frame`.

In a future PR the values of `%+v` and `%#v` will be extended to
implement a more readable stacktrace.