### PR TITLE
Extended stacktrace output

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -71,7 +71,9 @@ func (e _error) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			fmt.Fprintf(s, "%+v: ", e.Stacktrace()[0])
+			io.WriteString(s, e.msg)
+			fmt.Fprintf(s, "%+v", e.Stacktrace())
+			return
 		}
 		fallthrough
 	case 's':

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,22 @@ func ExampleNew_printf() {
 	err := errors.New("whoops")
 	fmt.Printf("%+v", err)
 
-	// Output: github.com/pkg/errors/example_test.go:17: whoops
+	// Example output:
+	// whoops
+	// github.com/pkg/errors_test.ExampleNew_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:17
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:106
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
 }
 
 func ExampleWrap() {
@@ -44,14 +59,34 @@ func ExampleCause() {
 	// error
 }
 
-func ExampleCause_printf() {
+func ExampleWrap_extended() {
 	err := fn()
 	fmt.Printf("%+v\n", err)
 
-	// Output: github.com/pkg/errors/example_test.go:32: error
-	// github.com/pkg/errors/example_test.go:33: inner
-	// github.com/pkg/errors/example_test.go:34: middle
-	// github.com/pkg/errors/example_test.go:35: outer
+	// Example output:
+	// error
+	// github.com/pkg/errors_test.fn
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.ExampleCause_printf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:63
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:104
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
+	// github.com/pkg/errors_test.fn
+	// 	  /home/dfc/src/github.com/pkg/errors/example_test.go:48: inner
+	// github.com/pkg/errors_test.fn
+	//        /home/dfc/src/github.com/pkg/errors/example_test.go:49: middle
+	// github.com/pkg/errors_test.fn
+	//      /home/dfc/src/github.com/pkg/errors/example_test.go:50: outer
 }
 
 func ExampleWrapf() {
@@ -62,11 +97,26 @@ func ExampleWrapf() {
 	// Output: oh noes #2: whoops
 }
 
-func ExampleErrorf() {
+func ExampleErrorf_extended() {
 	err := errors.Errorf("whoops: %s", "foo")
 	fmt.Printf("%+v", err)
 
-	// Output: github.com/pkg/errors/example_test.go:66: whoops: foo
+	// Example output:
+	// whoops: foo
+	// github.com/pkg/errors_test.ExampleErrorf
+	//         /home/dfc/src/github.com/pkg/errors/example_test.go:101
+	// testing.runExample
+	//         /home/dfc/go/src/testing/example.go:114
+	// testing.RunExamples
+	//         /home/dfc/go/src/testing/example.go:38
+	// testing.(*M).Run
+	//         /home/dfc/go/src/testing/testing.go:744
+	// main.main
+	//         /github.com/pkg/errors/_test/_testmain.go:102
+	// runtime.main
+	//         /home/dfc/go/src/runtime/proc.go:183
+	// runtime.goexit
+	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
 }
 
 func Example_stacktrace() {
@@ -82,5 +132,20 @@ func Example_stacktrace() {
 	st := err.Stacktrace()
 	fmt.Printf("%+v", st[0:2]) // top two frames
 
-	// Output: [github.com/pkg/errors/example_test.go:32 github.com/pkg/errors/example_test.go:77]
+	// Output: github.com/pkg/errors_test.fn
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
+	// github.com/pkg/errors_test.Example_stacktrace
+	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127
+}
+
+func ExampleCause_printf() {
+	err := errors.Wrap(func() error {
+		return func() error {
+			return errors.Errorf("hello %s", fmt.Sprintf("world"))
+		}()
+	}(), "failed")
+
+	fmt.Printf("%v", err)
+
+	// Output: failed: hello world
 }

--- a/example_test.go
+++ b/example_test.go
@@ -132,7 +132,8 @@ func Example_stacktrace() {
 	st := err.Stacktrace()
 	fmt.Printf("%+v", st[0:2]) // top two frames
 
-	// Output: github.com/pkg/errors_test.fn
+	// Example output:
+	// github.com/pkg/errors_test.fn
 	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
 	// github.com/pkg/errors_test.Example_stacktrace
 	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127

--- a/format_test.go
+++ b/format_test.go
@@ -126,8 +126,8 @@ func TestFormatWrapf(t *testing.T) {
 	}
 }
 
-func testFormatRegexp(t *testing.T, err error, format, want string) {
-	got := fmt.Sprintf(format, err)
+func testFormatRegexp(t *testing.T, arg interface{}, format, want string) {
+	got := fmt.Sprintf(format, arg)
 	lines := strings.SplitN(got, "\n", -1)
 	for i, w := range strings.SplitN(want, "\n", -1) {
 		match, err := regexp.MatchString(w, lines[i])

--- a/format_test.go
+++ b/format_test.go
@@ -3,28 +3,52 @@ package errors
 import (
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 )
 
-func TestFormat(t *testing.T) {
+func testFormat(t *testing.T, err error, format, want string) {
+	got := fmt.Sprintf(format, err)
+	lines := strings.SplitN(got, "\n", -1)
+	for i, w := range strings.SplitN(want, "\n", -1) {
+		if lines[i] != w {
+			t.Errorf("fmt.Sprintf(%q, err): got: %q, want: %q", format, got, want)
+		}
+	}
+}
+
+func TestFormatNew(t *testing.T) {
 	tests := []struct {
 		error
 		format string
 		want   string
 	}{{
+		New("error"),
+		"%s",
+		"error",
+	}, {
+		New("error"),
+		"%v",
+		"error",
+	}, {
+		New("error"),
+		"%+v",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatNew\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/format_test.go:34",
+	}}
 
-		New("error"),
-		"%s",
-		"error",
-	}, {
-		New("error"),
-		"%v",
-		"error",
-	}, {
-		New("error"),
-		"%+v",
-		"github.com/pkg/errors/format_test.go:24: error",
-	}, {
+	for _, tt := range tests {
+		testFormat(t, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatErrorf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
 		Errorf("%s", "error"),
 		"%s",
 		"error",
@@ -35,8 +59,22 @@ func TestFormat(t *testing.T) {
 	}, {
 		Errorf("%s", "error"),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:36: error",
-	}, {
+		"error\n" +
+			"github.com/pkg/errors.TestFormatErrorf\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/format_test.go:60",
+	}}
+
+	for _, tt := range tests {
+		testFormat(t, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrap(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
 		Wrap(New("error"), "error2"),
 		"%s",
 		"error2: error",
@@ -47,13 +85,26 @@ func TestFormat(t *testing.T) {
 	}, {
 		Wrap(New("error"), "error2"),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:48: error\n" +
-			"github.com/pkg/errors/format_test.go:48: error2",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrap\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/format_test.go:86",
 	}, {
 		Wrap(io.EOF, "error"),
 		"%s",
 		"error: EOF",
-	}, {
+	}}
+
+	for _, tt := range tests {
+		testFormat(t, tt.error, tt.format, tt.want)
+	}
+}
+
+func TestFormatWrapf(t *testing.T) {
+	tests := []struct {
+		error
+		format string
+		want   string
+	}{{
 		Wrapf(New("error"), "error%d", 2),
 		"%s",
 		"error2: error",
@@ -65,7 +116,8 @@ func TestFormat(t *testing.T) {
 		Wrap(io.EOF, "error"),
 		"%+v",
 		"EOF\n" +
-			"github.com/pkg/errors/format_test.go:65: error",
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/format_test.go:116: error",
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%v",
@@ -73,14 +125,12 @@ func TestFormat(t *testing.T) {
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%+v",
-		"github.com/pkg/errors/format_test.go:74: error\n" +
-			"github.com/pkg/errors/format_test.go:74: error2",
+		"error\n" +
+			"github.com/pkg/errors.TestFormatWrapf\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/format_test.go:126",
 	}}
 
 	for _, tt := range tests {
-		got := fmt.Sprintf(tt.format, tt.error)
-		if got != tt.want {
-			t.Errorf("fmt.Sprintf(%q, err): got: %q, want: %q", tt.format, got, tt.want)
-		}
+		testFormat(t, tt.error, tt.format, tt.want)
 	}
 }

--- a/format_test.go
+++ b/format_test.go
@@ -26,7 +26,7 @@ func TestFormatNew(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatNew\n" +
-			"\t/.+/github.com/pkg/errors/format_test.go:25",
+			"\t.+/github.com/pkg/errors/format_test.go:25",
 	}}
 
 	for _, tt := range tests {
@@ -52,7 +52,7 @@ func TestFormatErrorf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatErrorf\n" +
-			"\t/.+/github.com/pkg/errors/format_test.go:51",
+			"\t.+/github.com/pkg/errors/format_test.go:51",
 	}}
 
 	for _, tt := range tests {
@@ -78,7 +78,7 @@ func TestFormatWrap(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
-			"\t/.+/github.com/pkg/errors/format_test.go:77",
+			"\t.+/github.com/pkg/errors/format_test.go:77",
 	}, {
 		Wrap(io.EOF, "error"),
 		"%s",
@@ -108,7 +108,7 @@ func TestFormatWrapf(t *testing.T) {
 		"%+v",
 		"EOF\n" +
 			"github.com/pkg/errors.TestFormatWrapf\n" +
-			"\t/.+/github.com/pkg/errors/format_test.go:107: error",
+			"\t.+/github.com/pkg/errors/format_test.go:107: error",
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%v",
@@ -118,7 +118,7 @@ func TestFormatWrapf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatWrapf\n" +
-			"\t/.+/github.com/pkg/errors/format_test.go:117",
+			"\t.+/github.com/pkg/errors/format_test.go:117",
 	}}
 
 	for _, tt := range tests {

--- a/stack.go
+++ b/stack.go
@@ -59,7 +59,7 @@ func (f Frame) Format(s fmt.State, verb rune) {
 				io.WriteString(s, "unknown")
 			} else {
 				file, _ := fn.FileLine(pc)
-				io.WriteString(s, trimGOPATH(fn.Name(), file))
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
 			}
 		default:
 			io.WriteString(s, path.Base(f.file()))
@@ -84,7 +84,9 @@ func (st Stacktrace) Format(s fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case s.Flag('+'):
-			fmt.Fprintf(s, "%+v", []Frame(st))
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
 		case s.Flag('#'):
 			fmt.Fprintf(s, "%#v", []Frame(st))
 		default:

--- a/stack_test.go
+++ b/stack_test.go
@@ -188,8 +188,8 @@ func TestStacktrace(t *testing.T) {
 		},
 	}, {
 		func() error { return New("ooh") }(), []string{
-			"github.com/pkg/errors.TestStacktrace.func1\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New
+			`github.com/pkg/errors.(func·005|TestStacktrace.func1)` +
+				"\n\t/.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New
 			"github.com/pkg/errors.TestStacktrace\n" +
 				"\t/.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New's caller
 		},
@@ -199,10 +199,10 @@ func TestStacktrace(t *testing.T) {
 				return Errorf("hello %s", fmt.Sprintf("world"))
 			}()
 		}()), []string{
-			"github.com/pkg/errors.TestStacktrace.func2.1\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:199", // this is the stack of Errorf
-			"github.com/pkg/errors.TestStacktrace.func2\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:200", // this is the stack of Errorf's caller
+			`github.com/pkg/errors.(func·006|TestStacktrace.func2.1)` +
+				"\n\t/.+/github.com/pkg/errors/stack_test.go:199", // this is the stack of Errorf
+			`github.com/pkg/errors.(func·007|TestStacktrace.func2)` +
+				"\n\t/.+/github.com/pkg/errors/stack_test.go:200", // this is the stack of Errorf's caller
 			"github.com/pkg/errors.TestStacktrace\n" +
 				"\t/.+/github.com/pkg/errors/stack_test.go:201", // this is the stack of Errorf's caller's caller
 		},

--- a/stack_test.go
+++ b/stack_test.go
@@ -65,7 +65,8 @@ func TestFrameFormat(t *testing.T) {
 	}, {
 		Frame(initpc),
 		"%+s",
-		"github.com/pkg/errors/stack_test.go",
+		"github.com/pkg/errors.init\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/stack_test.go",
 	}, {
 		Frame(0),
 		"%s",
@@ -111,7 +112,8 @@ func TestFrameFormat(t *testing.T) {
 	}, {
 		Frame(initpc),
 		"%+v",
-		"github.com/pkg/errors/stack_test.go:9",
+		"github.com/pkg/errors.init\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:9",
 	}, {
 		Frame(0),
 		"%v",
@@ -175,20 +177,25 @@ func TestStacktrace(t *testing.T) {
 		want []string
 	}{{
 		New("ooh"), []string{
-			"github.com/pkg/errors/stack_test.go:177",
+			"github.com/pkg/errors.TestStacktrace\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:179",
 		},
 	}, {
 		Wrap(New("ooh"), "ahh"), []string{
-			"github.com/pkg/errors/stack_test.go:181", // this is the stack of Wrap, not New
+			"github.com/pkg/errors.TestStacktrace\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:184", // this is the stack of Wrap, not New
 		},
 	}, {
 		Cause(Wrap(New("ooh"), "ahh")), []string{
-			"github.com/pkg/errors/stack_test.go:185", // this is the stack of New
+			"github.com/pkg/errors.TestStacktrace\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:189", // this is the stack of New
 		},
 	}, {
 		func() error { return New("ooh") }(), []string{
-			"github.com/pkg/errors/stack_test.go:189", // this is the stack of New
-			"github.com/pkg/errors/stack_test.go:189", // this is the stack of New's caller
+			"github.com/pkg/errors.TestStacktrace.func1\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:194", // this is the stack of New
+			"github.com/pkg/errors.TestStacktrace\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:194", // this is the stack of New's caller
 		},
 	}, {
 		Cause(func() error {
@@ -196,9 +203,12 @@ func TestStacktrace(t *testing.T) {
 				return Errorf("hello %s", fmt.Sprintf("world"))
 			}()
 		}()), []string{
-			"github.com/pkg/errors/stack_test.go:196", // this is the stack of Errorf
-			"github.com/pkg/errors/stack_test.go:197", // this is the stack of Errorf's caller
-			"github.com/pkg/errors/stack_test.go:198", // this is the stack of Errorf's caller's caller
+			"github.com/pkg/errors.TestStacktrace.func2.1\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:203", // this is the stack of Errorf
+			"github.com/pkg/errors.TestStacktrace.func2\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:204", // this is the stack of Errorf's caller
+			"github.com/pkg/errors.TestStacktrace\n" +
+				"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:205", // this is the stack of Errorf's caller's caller
 		},
 	}}
 	for i, tt := range tests {
@@ -244,7 +254,7 @@ func TestStacktraceFormat(t *testing.T) {
 	}, {
 		nil,
 		"%+v",
-		"[]",
+		"",
 	}, {
 		nil,
 		"%#v",
@@ -260,7 +270,7 @@ func TestStacktraceFormat(t *testing.T) {
 	}, {
 		make(Stacktrace, 0),
 		"%+v",
-		"[]",
+		"",
 	}, {
 		make(Stacktrace, 0),
 		"%#v",
@@ -272,15 +282,19 @@ func TestStacktraceFormat(t *testing.T) {
 	}, {
 		stacktrace()[:2],
 		"%v",
-		"[stack_test.go:226 stack_test.go:273]",
+		"[stack_test.go:236 stack_test.go:283]",
 	}, {
 		stacktrace()[:2],
 		"%+v",
-		"[github.com/pkg/errors/stack_test.go:226 github.com/pkg/errors/stack_test.go:277]",
+		"\n" +
+			"github.com/pkg/errors.stacktrace\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:236\n" +
+			"github.com/pkg/errors.TestStacktraceFormat\n" +
+			"\t/home/dfc/src/github.com/pkg/errors/stack_test.go:287",
 	}, {
 		stacktrace()[:2],
 		"%#v",
-		"[]errors.Frame{stack_test.go:226, stack_test.go:281}",
+		"[]errors.Frame{stack_test.go:236, stack_test.go:295}",
 	}}
 
 	for i, tt := range tests {

--- a/stack_test.go
+++ b/stack_test.go
@@ -66,7 +66,7 @@ func TestFrameFormat(t *testing.T) {
 		Frame(initpc),
 		"%+s",
 		"github.com/pkg/errors.init\n" +
-			"\t/.+/github.com/pkg/errors/stack_test.go",
+			"\t.+/github.com/pkg/errors/stack_test.go",
 	}, {
 		Frame(0),
 		"%s",
@@ -113,7 +113,7 @@ func TestFrameFormat(t *testing.T) {
 		Frame(initpc),
 		"%+v",
 		"github.com/pkg/errors.init\n" +
-			"\t/.+/github.com/pkg/errors/stack_test.go:9",
+			"\t.+/github.com/pkg/errors/stack_test.go:9",
 	}, {
 		Frame(0),
 		"%v",
@@ -174,24 +174,24 @@ func TestStacktrace(t *testing.T) {
 	}{{
 		New("ooh"), []string{
 			"github.com/pkg/errors.TestStacktrace\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:175",
+				"\t.+/github.com/pkg/errors/stack_test.go:175",
 		},
 	}, {
 		Wrap(New("ooh"), "ahh"), []string{
 			"github.com/pkg/errors.TestStacktrace\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:180", // this is the stack of Wrap, not New
+				"\t.+/github.com/pkg/errors/stack_test.go:180", // this is the stack of Wrap, not New
 		},
 	}, {
 		Cause(Wrap(New("ooh"), "ahh")), []string{
 			"github.com/pkg/errors.TestStacktrace\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:185", // this is the stack of New
+				"\t.+/github.com/pkg/errors/stack_test.go:185", // this is the stack of New
 		},
 	}, {
 		func() error { return New("ooh") }(), []string{
 			`github.com/pkg/errors.(func·005|TestStacktrace.func1)` +
-				"\n\t/.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New
+				"\n\t.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New
 			"github.com/pkg/errors.TestStacktrace\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New's caller
+				"\t.+/github.com/pkg/errors/stack_test.go:190", // this is the stack of New's caller
 		},
 	}, {
 		Cause(func() error {
@@ -200,11 +200,11 @@ func TestStacktrace(t *testing.T) {
 			}()
 		}()), []string{
 			`github.com/pkg/errors.(func·006|TestStacktrace.func2.1)` +
-				"\n\t/.+/github.com/pkg/errors/stack_test.go:199", // this is the stack of Errorf
+				"\n\t.+/github.com/pkg/errors/stack_test.go:199", // this is the stack of Errorf
 			`github.com/pkg/errors.(func·007|TestStacktrace.func2)` +
-				"\n\t/.+/github.com/pkg/errors/stack_test.go:200", // this is the stack of Errorf's caller
+				"\n\t.+/github.com/pkg/errors/stack_test.go:200", // this is the stack of Errorf's caller
 			"github.com/pkg/errors.TestStacktrace\n" +
-				"\t/.+/github.com/pkg/errors/stack_test.go:201", // this is the stack of Errorf's caller's caller
+				"\t.+/github.com/pkg/errors/stack_test.go:201", // this is the stack of Errorf's caller's caller
 		},
 	}}
 	for _, tt := range tests {
@@ -280,9 +280,9 @@ func TestStacktraceFormat(t *testing.T) {
 		"%+v",
 		"\n" +
 			"github.com/pkg/errors.stacktrace\n" +
-			"\t/.+/github.com/pkg/errors/stack_test.go:228\n" +
+			"\t.+/github.com/pkg/errors/stack_test.go:228\n" +
 			"github.com/pkg/errors.TestStacktraceFormat\n" +
-			"\t/.+/github.com/pkg/errors/stack_test.go:279",
+			"\t.+/github.com/pkg/errors/stack_test.go:279",
 	}, {
 		stacktrace()[:2],
 		"%#v",


### PR DESCRIPTION
This PR introduces an "extended" stacktrace output to this package's error implementation controlled by the `%+v` verb.

An example of the `%+v` syntax, taken from `ExampleWrap`
```
hello world
github.com/pkg/errors_test.ExampleCause_extended.func1.1
        /home/dfc/src/github.com/pkg/errors/example_test.go:156
github.com/pkg/errors_test.ExampleCause_extended.func1
        /home/dfc/src/github.com/pkg/errors/example_test.go:157
github.com/pkg/errors_test.ExampleCause_extended
        /home/dfc/src/github.com/pkg/errors/example_test.go:158
testing.runExample
        /home/dfc/go/src/testing/example.go:114
testing.RunExamples
        /home/dfc/go/src/testing/example.go:38
testing.(*M).Run
        /home/dfc/go/src/testing/testing.go:744
main.main
        github.com/pkg/errors/_test/_testmain.go:104
runtime.main
        /home/dfc/go/src/runtime/proc.go:183
runtime.goexit
        /home/dfc/go/src/runtime/asm_amd64.s:2059
github.com/pkg/errors_test.ExampleCause_extended
        /home/dfc/src/github.com/pkg/errors/example_test.go:158: failed
```
The output takes some explaining.

- The first line `hello world` is the original text passed to `errors.Errorf`
- The second til the third to last are the stacktrace recorded at the time `errors.Errorf` was invoked.
- The Last two lines are the stack trace at the point `errors.Wrap` was called to wrap the previous error with the additional text `failed`. The stacktrace is not printed in this case, only the point at which the caller was invoked. Printing the additional stack trace is subject for further debate.

The PR is large, but that is due to the large impact it has on the tested output, the actual change to errors.go is 3 lines.