### PR TITLE
wrapper should serialize nicely to JSON

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -140,6 +140,10 @@ type wrapper struct {
 	*stack
 }
 
+func (w wrapper) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + w.Error() + `"`), nil
+}
+
 func (w wrapper) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':


### PR DESCRIPTION
without this patch, `wrapper` serializes to `JSON` similar to this:

```
{"error":{"stack":[534500,534894,525574,10756,389870,1776797,1771873,693326,682837,10507,202432,399841]}}
```

with this patch, `wrapper` serializes to `JSON` like this:

```
{"error":"error creating file: open dir: is a directory"}
```