### PR TITLE
Rename StackTrace interface to stacktracer in docs and examples

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@
 // New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
 // invoked. This information can be retrieved with the following interface.
 //
-//     type StackTrace interface {
+//     type stacktracer interface {
 //             StackTrace() errors.StackTrace
 //     }
 //
@@ -71,7 +71,7 @@
 // the fmt.Formatter interface that can be used for printing information about
 // the stacktrace of this error. For example:
 //
-//     if err, ok := err.(StackTrace); ok {
+//     if err, ok := err.(stacktracer); ok {
 //             for _, f := range err.StackTrace() {
 //                     fmt.Printf("%+s:%d", f)
 //             }

--- a/example_test.go
+++ b/example_test.go
@@ -120,13 +120,13 @@ func ExampleErrorf_extended() {
 }
 
 func Example_stacktrace() {
-	type StackTrace interface {
+	type stacktracer interface {
 		StackTrace() errors.StackTrace
 	}
 
-	err, ok := errors.Cause(fn()).(StackTrace)
+	err, ok := errors.Cause(fn()).(stacktracer)
 	if !ok {
-		panic("oops, err does not implement StackTrace")
+		panic("oops, err does not implement stacktracer")
 	}
 
 	st := err.StackTrace()


### PR DESCRIPTION
Replacement for #55 

/cc @kr @seh 