### PR TITLE
Capitalise first letter of trace.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,7 +59,7 @@
 // New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
 // invoked. This information can be retrieved with the following interface.
 //
-//     type stacktracer interface {
+//     type stackTracer interface {
 //             StackTrace() errors.StackTrace
 //     }
 //
@@ -67,11 +67,11 @@
 //
 //     type StackTrace []Frame
 //
-// The Frame type represents a call site in the stacktrace. Frame supports
+// The Frame type represents a call site in the stack trace. Frame supports
 // the fmt.Formatter interface that can be used for printing information about
-// the stacktrace of this error. For example:
+// the stack trace of this error. For example:
 //
-//     if err, ok := err.(stacktracer); ok {
+//     if err, ok := err.(stackTracer); ok {
 //             for _, f := range err.StackTrace() {
 //                     fmt.Printf("%+s:%d", f)
 //             }

--- a/example_test.go
+++ b/example_test.go
@@ -119,14 +119,14 @@ func ExampleErrorf_extended() {
 	//         /home/dfc/go/src/runtime/asm_amd64.s:2059
 }
 
-func Example_stacktrace() {
-	type stacktracer interface {
+func Example_stackTrace() {
+	type stackTracer interface {
 		StackTrace() errors.StackTrace
 	}
 
-	err, ok := errors.Cause(fn()).(stacktracer)
+	err, ok := errors.Cause(fn()).(stackTracer)
 	if !ok {
-		panic("oops, err does not implement stacktracer")
+		panic("oops, err does not implement stackTracer")
 	}
 
 	st := err.StackTrace()
@@ -135,7 +135,7 @@ func Example_stacktrace() {
 	// Example output:
 	// github.com/pkg/errors_test.fn
 	//	/home/dfc/src/github.com/pkg/errors/example_test.go:47
-	// github.com/pkg/errors_test.Example_stacktrace
+	// github.com/pkg/errors_test.Example_stackTrace
 	//	/home/dfc/src/github.com/pkg/errors/example_test.go:127
 }
 

--- a/stack_test.go
+++ b/stack_test.go
@@ -222,7 +222,7 @@ func TestStackTrace(t *testing.T) {
 	}
 }
 
-func stacktrace() StackTrace {
+func stackTrace() StackTrace {
 	const depth = 8
 	var pcs [depth]uintptr
 	n := runtime.Callers(1, pcs[:])
@@ -268,23 +268,23 @@ func TestStackTraceFormat(t *testing.T) {
 		"%#v",
 		`\[\]errors.Frame{}`,
 	}, {
-		stacktrace()[:2],
+		stackTrace()[:2],
 		"%s",
 		`\[stack_test.go stack_test.go\]`,
 	}, {
-		stacktrace()[:2],
+		stackTrace()[:2],
 		"%v",
 		`\[stack_test.go:228 stack_test.go:275\]`,
 	}, {
-		stacktrace()[:2],
+		stackTrace()[:2],
 		"%+v",
 		"\n" +
-			"github.com/pkg/errors.stacktrace\n" +
+			"github.com/pkg/errors.stackTrace\n" +
 			"\t.+/github.com/pkg/errors/stack_test.go:228\n" +
 			"github.com/pkg/errors.TestStackTraceFormat\n" +
 			"\t.+/github.com/pkg/errors/stack_test.go:279",
 	}, {
-		stacktrace()[:2],
+		stackTrace()[:2],
 		"%#v",
 		`\[\]errors.Frame{stack_test.go:228, stack_test.go:287}`,
 	}}


### PR DESCRIPTION
For consistency reasons I thought I would capitalise the first letter of the remaining 'traces' seeing as `Stacktrace` has now been changed to `StackTrace`.