### PR TITLE
errors: add a benchmark comparing stack trace performance

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,59 @@
+// +build go1.7
+
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	stderrors "errors"
+)
+
+func noErrors(at, depth int) error {
+	if at >= depth {
+		return stderrors.New("no error")
+	}
+	return noErrors(at+1, depth)
+}
+func yesErrors(at, depth int) error {
+	if at >= depth {
+		return New("ye error")
+	}
+	return yesErrors(at+1, depth)
+}
+
+func BenchmarkErrors(b *testing.B) {
+	var toperr error
+	type run struct {
+		stack int
+		std   bool
+	}
+	runs := []run{
+		{10, false},
+		{10, true},
+		{100, false},
+		{100, true},
+		{1000, false},
+		{1000, true},
+	}
+	for _, r := range runs {
+		part := "pkg/errors"
+		if r.std {
+			part = "errors"
+		}
+		name := fmt.Sprintf("%s-stack-%d", part, r.stack)
+		b.Run(name, func(b *testing.B) {
+			var err error
+			f := yesErrors
+			if r.std {
+				f = noErrors
+			}
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				err = f(0, r.stack)
+			}
+			b.StopTimer()
+			toperr = err
+		})
+	}
+}


### PR DESCRIPTION
Cost is roughly 1600 ns to 6000 ns depending on the stack size. Adds two additional allocations.

BenchmarkErrors/pkg/errors-stack-10-4         	 1000000	      1676 ns/op	     320 B/op	       3 allocs/op
BenchmarkErrors/errors-stack-10-4             	20000000	        64.9 ns/op	      16 B/op	       1 allocs/op
BenchmarkErrors/pkg/errors-stack-100-4        	  500000	      3058 ns/op	     320 B/op	       3 allocs/op
BenchmarkErrors/errors-stack-100-4            	 3000000	       472 ns/op	      16 B/op	       1 allocs/op
BenchmarkErrors/pkg/errors-stack-1000-4       	  200000	     10685 ns/op	     320 B/op	       3 allocs/op
BenchmarkErrors/errors-stack-1000-4           	  300000	      4523 ns/op	      16 B/op	       1 allocs/op

Fixes #72 
