### PR TITLE
Use runtime.CallersFrames for StackTrace

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -8,33 +8,9 @@ import (
 	"strings"
 )
 
-// Frame represents a program counter inside a stack frame.
-type Frame uintptr
-
-// pc returns the program counter for this frame;
-// multiple frames may have the same PC value.
-func (f Frame) pc() uintptr { return uintptr(f) - 1 }
-
-// file returns the full path to the file that contains the
-// function for this Frame's pc.
-func (f Frame) file() string {
-	fn := runtime.FuncForPC(f.pc())
-	if fn == nil {
-		return "unknown"
-	}
-	file, _ := fn.FileLine(f.pc())
-	return file
-}
-
-// line returns the line number of source code of the
-// function for this Frame's pc.
-func (f Frame) line() int {
-	fn := runtime.FuncForPC(f.pc())
-	if fn == nil {
-		return 0
-	}
-	_, line := fn.FileLine(f.pc())
-	return line
+// Frame holds call frame information from a stack trace.
+type Frame struct {
+	rf runtime.Frame
 }
 
 // Format formats the frame according to the fmt.Formatter interface.
@@ -51,23 +27,21 @@ func (f Frame) line() int {
 func (f Frame) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 's':
+		if f.rf.Func == nil {
+			io.WriteString(s, "unknown")
+			return
+		}
 		switch {
 		case s.Flag('+'):
-			pc := f.pc()
-			fn := runtime.FuncForPC(pc)
-			if fn == nil {
-				io.WriteString(s, "unknown")
-			} else {
-				file, _ := fn.FileLine(pc)
-				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
-			}
+			name := f.rf.Function
+			fmt.Fprintf(s, "%s\n\t%s", name, f.rf.File)
 		default:
-			io.WriteString(s, path.Base(f.file()))
+			io.WriteString(s, path.Base(f.rf.File))
 		}
 	case 'd':
-		fmt.Fprintf(s, "%d", f.line())
+		fmt.Fprintf(s, "%d", f.rf.Line)
 	case 'n':
-		name := runtime.FuncForPC(f.pc()).Name()
+		name := f.rf.Function
 		io.WriteString(s, funcname(name))
 	case 'v':
 		f.Format(s, 's')
@@ -101,12 +75,13 @@ func (st StackTrace) Format(s fmt.State, verb rune) {
 type stack []uintptr
 
 func (s *stack) Format(st fmt.State, verb rune) {
+	frames := s.StackTrace()
+
 	switch verb {
 	case 'v':
 		switch {
 		case st.Flag('+'):
-			for _, pc := range *s {
-				f := Frame(pc)
+			for _, f := range frames {
 				fmt.Fprintf(st, "\n%+v", f)
 			}
 		}
@@ -114,11 +89,18 @@ func (s *stack) Format(st fmt.State, verb rune) {
 }
 
 func (s *stack) StackTrace() StackTrace {
-	f := make([]Frame, len(*s))
-	for i := 0; i < len(f); i++ {
-		f[i] = Frame((*s)[i])
+	cframes := runtime.CallersFrames(*s)
+
+	frames := make([]Frame, 0, len(*s))
+	for {
+		f, more := cframes.Next()
+		frames = append(frames, Frame{f})
+		if !more {
+			break
+		}
 	}
-	return f
+
+	return frames
 }
 
 func callers() *stack {


### PR DESCRIPTION
Given the deprecation warning about runtime.FuncForPC in:
https://docs.google.com/presentation/d/1Wcblp3jpfeKwA0Y4FOmj63PW52M_qmNqlQkNaLj0P5o/edit?usp=sharing

I'd thought I'd see what a shift to use runtime.CallersFrames would look like. I'm not yet sure of the tradeoffs for one or the other, but thought I'd share code that passes existing tests locally in case its of interest.

