### PR TITLE
Add badge for number of dependent libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors) [![Sourcegraph](https://sourcegraph.com/github.com/pkg/errors/-/badge.svg)](https://sourcegraph.com/github.com/pkg/errors?badge)
 
 Package errors provides simple error handling primitives.
 


### PR DESCRIPTION
Thanks for the great package! Do you have any interest in adding this badge that shows how many people depend on it? It is a nice signal of quality.

Looks like this:
<img width="163" alt="screen shot 2017-03-08 at 10 48 08 pm" src="https://cloud.githubusercontent.com/assets/754768/23739140/d1a91b4e-0451-11e7-89dd-2aadb9fa43af.png">

More info:
https://text.sourcegraph.com/see-how-many-people-use-your-library-with-sourcegraph-badges-9750e56e7b2f#.xre5fottq

No problem if you don't want it, but wanted to offer.