### PR TITLE
Helper function for retrieving root stack trace from error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -267,3 +267,42 @@ func Cause(err error) error {
 	}
 	return err
 }
+
+// Trace returns the underlying stack trace of the error, if possible.
+// An error value has a stack trace if it implements the following
+// interface:
+//
+//     type stackTracer interface {
+//            StackTrace() errors.StackTrace
+//     }
+//
+// If the error does not implement StackTrace, nil will be returned.
+// If the error is nil, nil will be returned without further
+// investigation.
+func Trace(err error) (frames []Frame) {
+	if err == nil {
+		return nil
+	}
+
+	type stackTracer interface {
+		StackTrace() StackTrace
+	}
+
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		if stackTrace, ok := err.(stackTracer); ok {
+			frames = ([]Frame)(stackTrace.StackTrace())
+		}
+
+		if cause, ok := err.(causer); ok {
+			err = cause.Cause()
+		} else {
+			break
+		}
+	}
+
+	return
+}

--- a/stack.go
+++ b/stack.go
@@ -11,6 +11,11 @@ import (
 // Frame represents a program counter inside a stack frame.
 type Frame uintptr
 
+// Name returns the name of function for this Frame's pc.
+func (f Frame) Name() string {
+	return funcname(runtime.FuncForPC(f.pc()).Name())
+}
+
 // pc returns the program counter for this frame;
 // multiple frames may have the same PC value.
 func (f Frame) pc() uintptr { return uintptr(f) - 1 }

--- a/stack.go
+++ b/stack.go
@@ -15,9 +15,9 @@ type Frame uintptr
 // multiple frames may have the same PC value.
 func (f Frame) pc() uintptr { return uintptr(f) - 1 }
 
-// file returns the full path to the file that contains the
+// File returns the full path to the file that contains the
 // function for this Frame's pc.
-func (f Frame) file() string {
+func (f Frame) File() string {
 	fn := runtime.FuncForPC(f.pc())
 	if fn == nil {
 		return "unknown"
@@ -26,9 +26,9 @@ func (f Frame) file() string {
 	return file
 }
 
-// line returns the line number of source code of the
+// Line returns the line number of source code of the
 // function for this Frame's pc.
-func (f Frame) line() int {
+func (f Frame) Line() int {
 	fn := runtime.FuncForPC(f.pc())
 	if fn == nil {
 		return 0
@@ -62,13 +62,12 @@ func (f Frame) Format(s fmt.State, verb rune) {
 				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
 			}
 		default:
-			io.WriteString(s, path.Base(f.file()))
+			io.WriteString(s, path.Base(f.File()))
 		}
 	case 'd':
-		fmt.Fprintf(s, "%d", f.line())
+		fmt.Fprintf(s, "%d", f.Line())
 	case 'n':
-		name := runtime.FuncForPC(f.pc()).Name()
-		io.WriteString(s, funcname(name))
+		io.WriteString(s, f.Name())
 	case 'v':
 		f.Format(s, 's')
 		io.WriteString(s, ":")

--- a/stack_test.go
+++ b/stack_test.go
@@ -33,7 +33,7 @@ func TestFrameLine(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		got := tt.Frame.line()
+		got := tt.Frame.Line()
 		want := tt.want
 		if want != got {
 			t.Errorf("Frame(%v): want: %v, got: %v", uintptr(tt.Frame), want, got)


### PR DESCRIPTION
## Why

1. Want to retrieve function name, file and line separately.
    For now, the simplest way to do so is by using Formatter as follows.
    ```go
    for _, f := range err.StackTrace() {
      file := fmt.Sprintf("%s", f)
      line, _ := strconv.ParseInt(fmt.Sprintf("%d", f), 10, 32)
      funcName := fmt.Sprintf("%n", f)
      fmt.Printf("%s at %s:%d\n", funcName, file, line)
    }
    ```
2. These is no mechanism for extracting the *root* stack trace -- the longest stack trace.


### Use case

Most feasible use case is an integration with error reporting systems such as [honeybadger](https://github.com/honeybadger-io/honeybadger-go).

https://github.com/honeybadger-io/honeybadger-go/blob/f37170201ccce33edcb44f976565698c5aeb7fc4/error.go#L13-L17

```go
type Frame struct {
	Number string `json:"number"`
	File   string `json:"file"`
	Method string `json:"method"`
}
```

## What

Create a helper function `errors.Trace` which behaves like `errors.Cause` and returns the underlying stack trace (`[]Frame`) of the error.

```go
package main

import (
	built_in_errors "errors"
	"fmt"

	"github.com/pkg/errors"
)

func foo() error {
	return built_in_errors.New("foo")
}

func bar() error {
	return errors.Wrap(foo(), "foo in bar")
}

func baz() error {
	return errors.Wrap(bar(), "bar in baz")
}

func main() {
	err := errors.Wrap(baz(), "baz in main")

	if frames := errors.Trace(err); frames != nil {
		for _, f := range frames {
			fmt.Printf("%s at %s:%d\n", f.Name(), f.File(), f.Line())
		}
	}
}
```

```hcl
$ go run main.go
bar at /Users/ykiwng/Desktop/main.go:15
baz at /Users/ykiwng/Desktop/main.go:19
main at /Users/ykiwng/Desktop/main.go:23
main at /usr/local/Cellar/go/1.7.3/libexec/src/runtime/proc.go:183
goexit at /usr/local/Cellar/go/1.7.3/libexec/src/runtime/asm_amd64.s:2086
```