### PR TITLE
Add doc comment for exported Format func

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -79,6 +79,14 @@ func (f Frame) Format(s fmt.State, verb rune) {
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
 type StackTrace []Frame
 
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//    %s	lists source files for each Frame in the stack
+//    %v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':


### PR DESCRIPTION
https://goreportcard.com/report/github.com/pkg/errors

Currently, there is only one issue on the report for github.com/pkg/errors above. This PR fixes that issue, which was an undocumented, but exported, Format function.