### PR TITLE
Option to disable stack trace

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+var (
+	disableStack = false
+)
+
 // Frame represents a program counter inside a stack frame.
 type Frame uintptr
 
@@ -130,6 +134,9 @@ func (s *stack) StackTrace() StackTrace {
 }
 
 func callers() *stack {
+	if disableStack {
+		return nil
+	}
 	const depth = 32
 	var pcs [depth]uintptr
 	n := runtime.Callers(3, pcs[:])
@@ -183,4 +190,9 @@ func trimGOPATH(name, file string) string {
 	// get back to 0 or trim the leading separator
 	file = file[i+len(sep):]
 	return file
+}
+
+// AddStack will enable/disable stack trace in errors (for performance)
+func AddStack(add bool) {
+	disableStack = !add
 }


### PR DESCRIPTION
This adds a option to disable stack traces which have performance penalty.

A little benchmark:
```go
package main

import (
	"fmt"
	"testing"

	"github.com/pkg/errors"
)

var err1 = errors.New("hi")

func pkgError(err error, i int) error {
	return errors.Wrapf(err, "error number %d", i)
}

func fmtError(err error, i int) error {
	return fmt.Errorf("error number %d (%s)", i, err)
}

func BenchmarkPkg(b *testing.B) {
	for i := 0; i < b.N; i++ {
		pkgError(err1, i)
	}
}

func BenchmarkFmt(b *testing.B) {
	for i := 0; i < b.N; i++ {
		fmtError(err1, i)
	}
}

func BenchmarkPkgNoStack(b *testing.B) {
	errors.AddStack(false)
	defer errors.AddStack(true)
	for i := 0; i < b.N; i++ {
		pkgError(err1, i)
	}
}
```

Results in
```
$ go test -bench . /tmp/err_test.go
BenchmarkPkg-4          	 1000000	      1090 ns/op
BenchmarkFmt-4          	 5000000	       323 ns/op
BenchmarkPkgNoStack-4   	10000000	       212 ns/op
PASS
ok  	command-line-arguments	5.386s
```