### PR TITLE
Message(error) function, to make it easy to assert top most error

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -223,3 +223,31 @@ func TestErrorEquality(t *testing.T) {
 		}
 	}
 }
+
+func TestMessage(t *testing.T) {
+	tests := []struct {
+		err  error
+		want string
+	}{{
+		err:  nil,
+		want: "",
+	}, {
+		err:  New("whoops"),
+		want: "whoops",
+	}, {
+		err:  Wrap(New("main reason"), "whoops"),
+		want: "whoops",
+	}, {
+		err:  WithMessage(New("main reason"), "whoops"),
+		want: "whoops",
+	}, {
+		err:  WithStack(WithMessage(New("main reason"), "whoops")),
+		want: "whoops",
+	}}
+
+	for i, tt := range tests {
+		if got := Message(tt.err); tt.want != got {
+			t.Errorf("test %d: got %#v, want %#v", i+1, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Hi, I thought about adding a function to expose the message that is passed when wrapping an error since it may help checking which error has returned during the handling, well..to make more clear, here is a example of what I got stuck into:
```golang
package processor

import (
  "github.com/pkg/errors"
)

func Process() error {
  if err := validateState(); err != nil {
    return errors.Wrap(err, "validation failed")
  }

  if err := processData(); err != nil {
    return errors.Wrap(err, "processing failed")
  }

  return nil
}
```
Now consider that I'm calling function Process() from outside the package 'processor':
```golang
func main() {
  .
  .
  .
  if err != processor.Process(); err != nil {
    // Here I need to check if err variable contains a validation error or a processing error
    // so I can handle each accordingly.
  }
}
```
The problem here is that I can't determine which error is which without a minor - still not ideal - string processing, since the error message that I used in wrapping is suffixed with an arbitrary cause message with no direct way to split each.