### PR TITLE
Remove an unused argument of utility test func

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -491,7 +491,7 @@ type wrapper struct {
 	want []string
 }
 
-func prettyBlocks(blocks []string, prefix ...string) string {
+func prettyBlocks(blocks []string) string {
 	var out []string
 
 	for _, b := range blocks {


### PR DESCRIPTION
Found this by https://github.com/mvdan/unparam

I just found it when I try using unparam and run it against packages under $GOPATH randomly.
So, please just close it if you think it's too trivial.