### PR TITLE
reduce allocations when printing stack traces (#149)

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -1,10 +1,12 @@
 package errors
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -50,6 +52,11 @@ func (f Frame) line() int {
 //          GOPATH separated by \n\t (<funcname>\n\t<path>)
 //    %+v   equivalent to %+s:%d
 func (f Frame) Format(s fmt.State, verb rune) {
+	f.format(s, s, verb)
+}
+
+// format allows stack trace printing calls to be made with a bytes.Buffer.
+func (f Frame) format(w io.Writer, s fmt.State, verb rune) {
 	switch verb {
 	case 's':
 		switch {
@@ -57,23 +64,25 @@ func (f Frame) Format(s fmt.State, verb rune) {
 			pc := f.pc()
 			fn := runtime.FuncForPC(pc)
 			if fn == nil {
-				io.WriteString(s, "unknown")
+				io.WriteString(w, "unknown")
 			} else {
 				file, _ := fn.FileLine(pc)
-				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+				io.WriteString(w, fn.Name())
+				io.WriteString(w, "\n\t")
+				io.WriteString(w, file)
 			}
 		default:
-			io.WriteString(s, path.Base(f.file()))
+			io.WriteString(w, path.Base(f.file()))
 		}
 	case 'd':
-		fmt.Fprintf(s, "%d", f.line())
+		io.WriteString(w, strconv.Itoa(f.line()))
 	case 'n':
 		name := runtime.FuncForPC(f.pc()).Name()
-		io.WriteString(s, funcname(name))
+		io.WriteString(w, funcname(name))
 	case 'v':
-		f.Format(s, 's')
-		io.WriteString(s, ":")
-		f.Format(s, 'd')
+		f.format(w, s, 's')
+		io.WriteString(w, ":")
+		f.format(w, s, 'd')
 	}
 }
 
@@ -89,22 +98,49 @@ type StackTrace []Frame
 //
 //    %+v   Prints filename, function, and line number for each Frame in the stack.
 func (st StackTrace) Format(s fmt.State, verb rune) {
+	var b bytes.Buffer
 	switch verb {
 	case 'v':
 		switch {
 		case s.Flag('+'):
-			for _, f := range st {
-				fmt.Fprintf(s, "\n%+v", f)
+			b.Grow(len(st) * stackMinLen)
+			for _, fr := range st {
+				b.WriteByte('\n')
+				fr.format(&b, s, verb)
 			}
 		case s.Flag('#'):
-			fmt.Fprintf(s, "%#v", []Frame(st))
+			fmt.Fprintf(&b, "%#v", []Frame(st))
 		default:
-			fmt.Fprintf(s, "%v", []Frame(st))
+			st.formatSlice(&b, s, verb)
 		}
 	case 's':
-		fmt.Fprintf(s, "%s", []Frame(st))
+		st.formatSlice(&b, s, verb)
 	}
+	io.Copy(s, &b)
 }
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(b *bytes.Buffer, s fmt.State, verb rune) {
+	b.WriteByte('[')
+	if len(st) == 0 {
+		b.WriteByte(']')
+		return
+	}
+
+	b.Grow(len(st) * (stackMinLen / 4))
+	st[0].format(b, s, verb)
+	for _, fr := range st[1:] {
+		b.WriteByte(' ')
+		fr.format(b, s, verb)
+	}
+	b.WriteByte(']')
+}
+
+// stackMinLen is a best-guess at the minimum length of a stack trace. It
+// doesn't need to be exact, just give a good enough head start for the buffer
+// to avoid the expensive early growth.
+const stackMinLen = 96
 
 // stack represents a stack of program counters.
 type stack []uintptr
@@ -114,10 +150,14 @@ func (s *stack) Format(st fmt.State, verb rune) {
 	case 'v':
 		switch {
 		case st.Flag('+'):
+			var b bytes.Buffer
+			b.Grow(len(*s) * stackMinLen)
 			for _, pc := range *s {
 				f := Frame(pc)
-				fmt.Fprintf(st, "\n%+v", f)
+				b.WriteByte('\n')
+				f.format(&b, st, 'v')
 			}
+			io.Copy(st, &b)
 		}
 	}
 }


### PR DESCRIPTION
This implements proposal in #149 by adding a format method to `Frame` that accepts an `io.Writer`, allowing `stack` and `StackTrace` to grow a `bytes.Buffer` ahead of time. The benefits are illustrated in the benchmark comparison below, in summary allocations are reduced by 90-97% resulting in a 40-55% performance boost.

This comes at a slight cost in bytes used, which is around 5% higher on average with a single case reaching 36% (small stack, %s) which is probably not worth special casing. This trade off can be affected by adjusting stackMinLen with a more generous multiplier, lowering allocations at the expense of unused buffer.

```
benchmark                                         old ns/op     new ns/op     delta
BenchmarkStackFormatting/%s-stack-10-24           411           402           -2.19%
BenchmarkStackFormatting/%v-stack-10-24           411           416           +1.22%
BenchmarkStackFormatting/%+v-stack-10-24          29551         17147         -41.97%
BenchmarkStackFormatting/%s-stack-30-24           377           410           +8.75%
BenchmarkStackFormatting/%v-stack-30-24           411           385           -6.33%
BenchmarkStackFormatting/%+v-stack-30-24          65337         29997         -54.09%
BenchmarkStackFormatting/%s-stack-60-24           444           396           -10.81%
BenchmarkStackFormatting/%v-stack-60-24           441           385           -12.70%
BenchmarkStackFormatting/%+v-stack-60-24          67739         31652         -53.27%
BenchmarkStackFormatting/%s-stacktrace-10-24      12894         7409          -42.54%
BenchmarkStackFormatting/%v-stacktrace-10-24      20893         11611         -44.43%
BenchmarkStackFormatting/%+v-stacktrace-10-24     31120         17046         -45.22%
BenchmarkStackFormatting/%s-stacktrace-30-24      24363         13724         -43.67%
BenchmarkStackFormatting/%v-stacktrace-30-24      48716         23995         -50.75%
BenchmarkStackFormatting/%+v-stacktrace-30-24     68169         31939         -53.15%
BenchmarkStackFormatting/%s-stacktrace-60-24      25448         14208         -44.17%
BenchmarkStackFormatting/%v-stacktrace-60-24      46780         24099         -48.48%
BenchmarkStackFormatting/%+v-stacktrace-60-24     68103         34016         -50.05%

benchmark                                         old allocs     new allocs     delta
BenchmarkStackFormatting/%s-stack-10-24           2              2              +0.00%
BenchmarkStackFormatting/%v-stack-10-24           2              2              +0.00%
BenchmarkStackFormatting/%+v-stack-10-24          77             7              -90.91%
BenchmarkStackFormatting/%s-stack-30-24           2              2              +0.00%
BenchmarkStackFormatting/%v-stack-30-24           2              2              +0.00%
BenchmarkStackFormatting/%+v-stack-30-24          162            4              -97.53%
BenchmarkStackFormatting/%s-stack-60-24           2              2              +0.00%
BenchmarkStackFormatting/%v-stack-60-24           2              2              +0.00%
BenchmarkStackFormatting/%+v-stack-60-24          162            4              -97.53%
BenchmarkStackFormatting/%s-stacktrace-10-24      33             4              -87.88%
BenchmarkStackFormatting/%v-stacktrace-10-24      63             7              -88.89%
BenchmarkStackFormatting/%+v-stacktrace-10-24     77             7              -90.91%
BenchmarkStackFormatting/%s-stacktrace-30-24      67             4              -94.03%
BenchmarkStackFormatting/%v-stacktrace-30-24      131            4              -96.95%
BenchmarkStackFormatting/%+v-stacktrace-30-24     162            4              -97.53%
BenchmarkStackFormatting/%s-stacktrace-60-24      67             4              -94.03%
BenchmarkStackFormatting/%v-stacktrace-60-24      131            4              -96.95%
BenchmarkStackFormatting/%+v-stacktrace-60-24     162            4              -97.53%

benchmark                                         old bytes     new bytes     delta
BenchmarkStackFormatting/%s-stack-10-24           16            16            +0.00%
BenchmarkStackFormatting/%v-stack-10-24           16            16            +0.00%
BenchmarkStackFormatting/%+v-stack-10-24          2647          2954          +11.60%
BenchmarkStackFormatting/%s-stack-30-24           16            16            +0.00%
BenchmarkStackFormatting/%v-stack-30-24           16            16            +0.00%
BenchmarkStackFormatting/%+v-stack-30-24          5923          6269          +5.84%
BenchmarkStackFormatting/%s-stack-60-24           16            16            +0.00%
BenchmarkStackFormatting/%v-stack-60-24           16            16            +0.00%
BenchmarkStackFormatting/%+v-stack-60-24          5923          6269          +5.84%
BenchmarkStackFormatting/%s-stacktrace-10-24      632           864           +36.71%
BenchmarkStackFormatting/%v-stacktrace-10-24      920           924           +0.43%
BenchmarkStackFormatting/%+v-stacktrace-10-24     2671          2975          +11.38%
BenchmarkStackFormatting/%s-stacktrace-30-24      1313          1521          +15.84%
BenchmarkStackFormatting/%v-stacktrace-30-24      1922          1617          -15.87%
BenchmarkStackFormatting/%+v-stacktrace-30-24     5949          6295          +5.82%
BenchmarkStackFormatting/%s-stacktrace-60-24      1313          1521          +15.84%
BenchmarkStackFormatting/%v-stacktrace-60-24      1922          1617          -15.87%
BenchmarkStackFormatting/%+v-stacktrace-60-24     5949          5910          -0.66%
```