### PR TITLE
Allow version-tagged filepath in tests

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -27,7 +27,7 @@ func TestFormatNew(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatNew\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:26",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:26",
 	}, {
 		New("error"),
 		"%q",
@@ -57,7 +57,7 @@ func TestFormatErrorf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatErrorf\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:56",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:56",
 	}}
 
 	for i, tt := range tests {
@@ -83,7 +83,7 @@ func TestFormatWrap(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:82",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:82",
 	}, {
 		Wrap(io.EOF, "error"),
 		"%s",
@@ -98,14 +98,14 @@ func TestFormatWrap(t *testing.T) {
 		"EOF\n" +
 			"error\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:96",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:96",
 	}, {
 		Wrap(Wrap(io.EOF, "error1"), "error2"),
 		"%+v",
 		"EOF\n" +
 			"error1\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:103\n",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:103\n",
 	}, {
 		Wrap(New("error with space"), "context"),
 		"%q",
@@ -136,7 +136,7 @@ func TestFormatWrapf(t *testing.T) {
 		"EOF\n" +
 			"error2\n" +
 			"github.com/pkg/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:134",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:134",
 	}, {
 		Wrapf(New("error"), "error%d", 2),
 		"%s",
@@ -150,7 +150,7 @@ func TestFormatWrapf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pkg/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pkg/errors/format_test.go:149",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:149",
 	}}
 
 	for i, tt := range tests {
@@ -176,7 +176,7 @@ func TestFormatWithStack(t *testing.T) {
 		"%+v",
 		[]string{"EOF",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:175"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:175"},
 	}, {
 		WithStack(New("error")),
 		"%s",
@@ -190,36 +190,36 @@ func TestFormatWithStack(t *testing.T) {
 		"%+v",
 		[]string{"error",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:189",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:189",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:189"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:189"},
 	}, {
 		WithStack(WithStack(io.EOF)),
 		"%+v",
 		[]string{"EOF",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:197",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:197",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:197"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:197"},
 	}, {
 		WithStack(WithStack(Wrapf(io.EOF, "message"))),
 		"%+v",
 		[]string{"EOF",
 			"message",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:205",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:205",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:205",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:205",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:205"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:205"},
 	}, {
 		WithStack(Errorf("error%d", 1)),
 		"%+v",
 		[]string{"error1",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:216",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:216",
 			"github.com/pkg/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:216"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:216"},
 	}}
 
 	for i, tt := range tests {
@@ -246,7 +246,7 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"error",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:244",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:244",
 			"error2"},
 	}, {
 		WithMessage(io.EOF, "addition1"),
@@ -273,13 +273,13 @@ func TestFormatWithMessage(t *testing.T) {
 		"%+v",
 		[]string{"EOF", "error1", "error2",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:272"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:272"},
 	}, {
 		WithMessage(Errorf("error%d", 1), "error2"),
 		"%+v",
 		[]string{"error1",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:278",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:278",
 			"error2"},
 	}, {
 		WithMessage(WithStack(io.EOF), "error"),
@@ -287,7 +287,7 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"EOF",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:285",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:285",
 			"error"},
 	}, {
 		WithMessage(Wrap(WithStack(io.EOF), "inside-error"), "outside-error"),
@@ -295,10 +295,10 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"EOF",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:293",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:293",
 			"inside-error",
 			"github.com/pkg/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:293",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:293",
 			"outside-error"},
 	}}
 
@@ -315,11 +315,11 @@ func TestFormatGeneric(t *testing.T) {
 		{New("new-error"), []string{
 			"new-error",
 			"github.com/pkg/errors.TestFormatGeneric\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:315"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:315"},
 		}, {Errorf("errorf-error"), []string{
 			"errorf-error",
 			"github.com/pkg/errors.TestFormatGeneric\n" +
-				"\t.+/github.com/pkg/errors/format_test.go:319"},
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/format_test.go:319"},
 		}, {errors.New("errors-new-error"), []string{
 			"errors-new-error"},
 		},
@@ -333,21 +333,21 @@ func TestFormatGeneric(t *testing.T) {
 			func(err error) error { return WithStack(err) },
 			[]string{
 				"github.com/pkg/errors.(func·002|TestFormatGeneric.func2)\n\t" +
-					".+/github.com/pkg/errors/format_test.go:333",
+					".+/github.com/pkg/errors(@v[^/]+)?/format_test.go:333",
 			},
 		}, {
 			func(err error) error { return Wrap(err, "wrap-error") },
 			[]string{
 				"wrap-error",
 				"github.com/pkg/errors.(func·003|TestFormatGeneric.func3)\n\t" +
-					".+/github.com/pkg/errors/format_test.go:339",
+					".+/github.com/pkg/errors(@v[^/]+)?/format_test.go:339",
 			},
 		}, {
 			func(err error) error { return Wrapf(err, "wrapf-error%d", 1) },
 			[]string{
 				"wrapf-error1",
 				"github.com/pkg/errors.(func·004|TestFormatGeneric.func4)\n\t" +
-					".+/github.com/pkg/errors/format_test.go:346",
+					".+/github.com/pkg/errors(@v[^/]+)?/format_test.go:346",
 			},
 		},
 	}

--- a/stack_test.go
+++ b/stack_test.go
@@ -66,7 +66,7 @@ func TestFrameFormat(t *testing.T) {
 		Frame(initpc),
 		"%+s",
 		"github.com/pkg/errors.init\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go",
 	}, {
 		Frame(0),
 		"%s",
@@ -113,7 +113,7 @@ func TestFrameFormat(t *testing.T) {
 		Frame(initpc),
 		"%+v",
 		"github.com/pkg/errors.init\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go:9",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:9",
 	}, {
 		Frame(0),
 		"%v",
@@ -153,24 +153,24 @@ func TestStackTrace(t *testing.T) {
 	}{{
 		New("ooh"), []string{
 			"github.com/pkg/errors.TestStackTrace\n" +
-				"\t.+/github.com/pkg/errors/stack_test.go:154",
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:154",
 		},
 	}, {
 		Wrap(New("ooh"), "ahh"), []string{
 			"github.com/pkg/errors.TestStackTrace\n" +
-				"\t.+/github.com/pkg/errors/stack_test.go:159", // this is the stack of Wrap, not New
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:159", // this is the stack of Wrap, not New
 		},
 	}, {
 		Cause(Wrap(New("ooh"), "ahh")), []string{
 			"github.com/pkg/errors.TestStackTrace\n" +
-				"\t.+/github.com/pkg/errors/stack_test.go:164", // this is the stack of New
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:164", // this is the stack of New
 		},
 	}, {
 		func() error { return New("ooh") }(), []string{
 			`github.com/pkg/errors.(func·009|TestStackTrace.func1)` +
-				"\n\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New
+				"\n\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:169", // this is the stack of New
 			"github.com/pkg/errors.TestStackTrace\n" +
-				"\t.+/github.com/pkg/errors/stack_test.go:169", // this is the stack of New's caller
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:169", // this is the stack of New's caller
 		},
 	}, {
 		Cause(func() error {
@@ -179,11 +179,11 @@ func TestStackTrace(t *testing.T) {
 			}()
 		}()), []string{
 			`github.com/pkg/errors.(func·010|TestStackTrace.func2.1)` +
-				"\n\t.+/github.com/pkg/errors/stack_test.go:178", // this is the stack of Errorf
+				"\n\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:178", // this is the stack of Errorf
 			`github.com/pkg/errors.(func·011|TestStackTrace.func2)` +
-				"\n\t.+/github.com/pkg/errors/stack_test.go:179", // this is the stack of Errorf's caller
+				"\n\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:179", // this is the stack of Errorf's caller
 			"github.com/pkg/errors.TestStackTrace\n" +
-				"\t.+/github.com/pkg/errors/stack_test.go:180", // this is the stack of Errorf's caller's caller
+				"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:180", // this is the stack of Errorf's caller's caller
 		},
 	}}
 	for i, tt := range tests {
@@ -259,9 +259,9 @@ func TestStackTraceFormat(t *testing.T) {
 		"%+v",
 		"\n" +
 			"github.com/pkg/errors.stackTrace\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go:207\n" +
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:207\n" +
 			"github.com/pkg/errors.TestStackTraceFormat\n" +
-			"\t.+/github.com/pkg/errors/stack_test.go:258",
+			"\t.+/github.com/pkg/errors(@v[^/]+)?/stack_test.go:258",
 	}, {
 		stackTrace()[:2],
 		"%#v",


### PR DESCRIPTION
Go 1.11 will introduce support for [versioned modules](https://github.com/golang/go/wiki/Modules). When downloading module dependencies, `go get` will add a version tag to the directory where the package is checked out (e.g., `github.com/pkg/errors@v0.8.0`).

It is also recommended as a best practice to run `go test all` before release, which will run tests for the package being released and all dependencies to check compatibility. Currently this fails because the tests are not happy to be checked out in a version-tagged directory.

```
$ cat go.mod 
module github.com/thsnr/gomod

require github.com/pkg/errors v0.0.0-00000000000000-816c9085562cd7ee03e7f8188a1cfd942858cded

$ go1.11rc1 test all
?   	github.com/thsnr/gomod	[no test files]
...
--- FAIL: TestFrameFormat (0.00s)
    format_test.go:379: test 2: line 2: fmt.Sprintf("%+s", err):
         got: "github.com/pkg/errors.init\n\t/home/tiit/go/pkg/mod/github.com/pkg/errors@v0.0.0-00000000000000-816c9085562cd7ee03e7f8188a1cfd942858cded/stack_test.go"
        want: "github.com/pkg/errors.init\n\t.+/github.com/pkg/errors/stack_test.go"
    format_test.go:379: test 12: line 2: fmt.Sprintf("%+v", err):
         got: "github.com/pkg/errors.init\n\t/home/tiit/go/pkg/mod/github.com/pkg/errors@v0.0.0-00000000000000-816c9085562cd7ee03e7f8188a1cfd942858cded/stack_test.go:9"
        want: "github.com/pkg/errors.init\n\t.+/github.com/pkg/errors/stack_test.go:9"
...
```

This pull request simply changes the tests to allow a version tag. I purposefully left the version regular expression vague (`@v[^/]+`) to keep it short – these tests should not concern themselves with correctness of the tag – and inlined it to avoid changing any line numbers.