### PR TITLE
make the output of embedded errors more readable

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -245,7 +245,7 @@ func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			fmt.Fprintf(s, "%+v\n", w.Cause())
+			fmt.Fprintf(s, "%+v\n====================\n", w.Cause())
 			io.WriteString(s, w.msg)
 			return
 		}

--- a/format_test.go
+++ b/format_test.go
@@ -95,14 +95,14 @@ func TestFormatWrap(t *testing.T) {
 	}, {
 		Wrap(io.EOF, "error"),
 		"%+v",
-		"EOF\n" +
+		"EOF\n" + "=+\n" +
 			"error\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
 			"\t.+/github.com/pkg/errors/format_test.go:96",
 	}, {
 		Wrap(Wrap(io.EOF, "error1"), "error2"),
 		"%+v",
-		"EOF\n" +
+		"EOF\n" + "=+\n" +
 			"error1\n" +
 			"github.com/pkg/errors.TestFormatWrap\n" +
 			"\t.+/github.com/pkg/errors/format_test.go:103\n",
@@ -133,7 +133,7 @@ func TestFormatWrapf(t *testing.T) {
 	}, {
 		Wrapf(io.EOF, "error%d", 2),
 		"%+v",
-		"EOF\n" +
+		"EOF\n" + "=+\n" +
 			"error2\n" +
 			"github.com/pkg/errors.TestFormatWrapf\n" +
 			"\t.+/github.com/pkg/errors/format_test.go:134",
@@ -408,6 +408,9 @@ func parseBlocks(input string, detectStackboundaries bool) ([]string, error) {
 	lines := map[string]bool{} // already found lines
 
 	for _, l := range strings.Split(input, "\n") {
+		if l == "====================" {
+			continue
+		}
 		isStackLine := stackLineR.MatchString(l)
 
 		switch {


### PR DESCRIPTION
sample code
``` go
err1 := errors.New("bomb 1")
err2 := errors.Wrap(err1, "bomb 2")
fmt.Printf("%+v\n", err2)
```
original output
```
bomb 1
main.main
	/Users/foo/golang/src/foo/x.go:20
runtime.main
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/proc.go:201
runtime.goexit
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/asm_amd64.s:1333
bomb 2
main.main
	/Users/foo/golang/src/foo/x.go:21
runtime.main
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/proc.go:201
runtime.goexit
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/asm_amd64.s:1333

```
new output
```
bomb 1
main.main
	/Users/foo/golang/src/foo/x.go:20
runtime.main
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/proc.go:201
runtime.goexit
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/asm_amd64.s:1333
====================
bomb 2
main.main
	/Users/foo/golang/src/foo/x.go:21
runtime.main
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/proc.go:201
runtime.goexit
	/usr/local/Cellar/go/1.11.2/libexec/src/runtime/asm_amd64.s:1333
```