### PR TITLE
Fixes a documentation typo

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -82,7 +82,7 @@
 //
 //     if err, ok := err.(stackTracer); ok {
 //             for _, f := range err.StackTrace() {
-//                     fmt.Printf("%+s:%d", f)
+//                     fmt.Printf("%+s:%d\n", f, f)
 //             }
 //     }
 //


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

Without this patch the example output looks like this:

```
$ go run main2.go 
main.wrapMe
	/Users/cha/test/main2.go:%!d(MISSING)main.main
	/Users/cha/test/main2.go:%!d(MISSING)runtime.main
	/Users/cha/.gimme/versions/go1.11.2.darwin.amd64/src/runtime/proc.go:%!d(MISSING)runtime.goexit
	/Users/cha/.gimme/versions/go1.11.2.darwin.amd64/src/runtime/asm_amd64.s:%!d(MISSING)```

After the change:

```
$ go run main2.go 
main.wrapMe
	/Users/cha/test/main2.go:32
main.main
	/Users/cha/test/main2.go:19
runtime.main
	/Users/cha/.gimme/versions/go1.11.2.darwin.amd64/src/runtime/proc.go:201
runtime.goexit
	/Users/cha/.gimme/versions/go1.11.2.darwin.amd64/src/runtime/asm_amd64.s:1333
```
