### PR TITLE
travis: remove Go 1.8 and earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.4.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
   - 1.9.x
   - 1.10.x
   - 1.11.x


### PR DESCRIPTION
Remove support for Go 1.8 and earlier as they are

a. no longer supported upstream
b. lack support for runtime.CallerFrames

Signed-off-by: Dave Cheney <dave@cheney.net>