### PR TITLE
Makefile: switch to staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PKGS := github.com/pkg/errors
 SRCDIRS := $(shell go list -f '{{.Dir}}' $(PKGS))
 GO := go
 
-check: test vet gofmt unused misspell unconvert gosimple ineffassign
+check: test vet gofmt misspell unconvert staticcheck ineffassign unparam
 
 test: 
 	$(GO) test $(PKGS)
@@ -12,11 +12,7 @@ vet: | test
 
 staticcheck:
 	$(GO) get honnef.co/go/tools/cmd/staticcheck
-	staticcheck $(PKGS)
-
-unused:
-	$(GO) get honnef.co/go/tools/cmd/unused
-	unused -exported $(PKGS)
+	staticcheck -checks all $(PKGS)
 
 misspell:
 	$(GO) get github.com/client9/misspell/cmd/misspell
@@ -29,15 +25,11 @@ unconvert:
 	$(GO) get github.com/mdempsky/unconvert
 	unconvert -v $(PKGS)
 
-gosimple:
-	$(GO) get honnef.co/go/tools/cmd/gosimple
-	gosimple $(PKGS)
-
 ineffassign:
 	$(GO) get github.com/gordonklaus/ineffassign
 	find $(SRCDIRS) -name '*.go' | xargs ineffassign
 
-pedantic: check unparam errcheck staticcheck
+pedantic: check errcheck
 
 unparam:
 	$(GO) get mvdan.cc/unparam


### PR DESCRIPTION
Remove deprecated linters that have been rolled into staticcheck.

Signed-off-by: Dave Cheney <dave@cheney.net>