### PR TITLE
Modules: add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/pkg/errors


### PR DESCRIPTION
Adds a bare go.mod file to support working outside of GOPATH, and to
play nicely with the Go modules ecosystem.

Resolves issue #190.