### PR TITLE
Return errors.Frame to a uintptr

### DIFF
--- a/format_test.go
+++ b/format_test.go
@@ -385,6 +385,7 @@ func TestFormatWrappedNew(t *testing.T) {
 }
 
 func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string) {
+	t.Helper()
 	got := fmt.Sprintf(format, arg)
 	gotLines := strings.SplitN(got, "\n", -1)
 	wantLines := strings.SplitN(want, "\n", -1)

--- a/stack_test.go
+++ b/stack_test.go
@@ -35,11 +35,11 @@ func TestFrameFormat(t *testing.T) {
 		"github.com/pkg/errors.init\n" +
 			"\t.+/github.com/pkg/errors/stack_test.go",
 	}, {
-		Frame{},
+		0,
 		"%s",
 		"unknown",
 	}, {
-		Frame{},
+		0,
 		"%+s",
 		"unknown",
 	}, {
@@ -47,7 +47,7 @@ func TestFrameFormat(t *testing.T) {
 		"%d",
 		"9",
 	}, {
-		Frame{},
+		0,
 		"%d",
 		"0",
 	}, {
@@ -69,7 +69,7 @@ func TestFrameFormat(t *testing.T) {
 		"%n",
 		"X.val",
 	}, {
-		Frame{},
+		0,
 		"%n",
 		"",
 	}, {
@@ -82,7 +82,7 @@ func TestFrameFormat(t *testing.T) {
 		"github.com/pkg/errors.init\n" +
 			"\t.+/github.com/pkg/errors/stack_test.go:9",
 	}, {
-		Frame{},
+		0,
 		"%v",
 		"unknown:0",
 	}}
@@ -246,7 +246,7 @@ func caller() Frame {
 	n := runtime.Callers(2, pcs[:])
 	frames := runtime.CallersFrames(pcs[:n])
 	frame, _ := frames.Next()
-	return Frame(frame)
+	return Frame(frame.PC)
 }
 
 //go:noinline


### PR DESCRIPTION
Updates aws/aws-xray-sdk-go#77
Updates evalphobia/logrus_sentry#74

Go 1.12 has updated the behaviour of runtime.FuncForPC so that it
behaves as it did in Go 1.11 and earlier.

This allows errors.Frame to return to a uintptr representing the PC +1
of the caller. This will fix the build breakages of projects that were
tracking HEAD of this package.

Signed-off-by: Dave Cheney <dave@cheney.net>