### PR TITLE
Add json.Marshaler support to the Frame type.

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,29 @@
+package errors
+
+import (
+	"encoding/json"
+	"regexp"
+	"testing"
+)
+
+func TestFrameMarshalJSON(t *testing.T) {
+	var tests = []struct {
+		Frame
+		want string
+	}{{
+		initpc,
+		`^"github.com/pkg/errors.init .+/github.com/pkg/errors/stack_test.go:\d+"$`,
+	}, {
+		0,
+		`^"unknown"$`,
+	}}
+	for i, tt := range tests {
+		got, err := json.Marshal(tt.Frame)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !regexp.MustCompile(tt.want).Match(got) {
+			t.Errorf("test %d: MarshalJSON:\n got %q\n want %q", i+1, string(got), tt.want)
+		}
+	}
+}

--- a/json_test.go
+++ b/json_test.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+func TestFrameMarshalText(t *testing.T) {
+	var tests = []struct {
+		Frame
+		want string
+	}{{
+		initpc,
+		`^github.com/pkg/errors\.init(\.ializers)? .+/github\.com/pkg/errors/stack_test.go:\d+$`,
+	}, {
+		0,
+		`^unknown$`,
+	}}
+	for i, tt := range tests {
+		got, err := tt.Frame.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !regexp.MustCompile(tt.want).Match(got) {
+			t.Errorf("test %d: MarshalJSON:\n got %q\n want %q", i+1, string(got), tt.want)
+		}
+	}
+}
+
 func TestFrameMarshalJSON(t *testing.T) {
 	var tests = []struct {
 		Frame

--- a/json_test.go
+++ b/json_test.go
@@ -12,7 +12,7 @@ func TestFrameMarshalJSON(t *testing.T) {
 		want string
 	}{{
 		initpc,
-		`^"github.com/pkg/errors.init .+/github.com/pkg/errors/stack_test.go:\d+"$`,
+		`^"github.com/pkg/errors.init(.ializers)? .+/github.com/pkg/errors/stack_test.go:\d+"$`,
 	}, {
 		0,
 		`^"unknown"$`,

--- a/json_test.go
+++ b/json_test.go
@@ -12,7 +12,7 @@ func TestFrameMarshalJSON(t *testing.T) {
 		want string
 	}{{
 		initpc,
-		`^"github.com/pkg/errors.init(.ializers)? .+/github.com/pkg/errors/stack_test.go:\d+"$`,
+		`^"github\.com/pkg/errors\.init(\.ializers)? .+/github\.com/pkg/errors/stack_test.go:\d+"$`,
 	}, {
 		0,
 		`^"unknown"$`,

--- a/stack.go
+++ b/stack.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"path"
@@ -81,6 +82,18 @@ func (f Frame) Format(s fmt.State, verb rune) {
 		io.WriteString(s, ":")
 		f.Format(s, 'd')
 	}
+}
+
+// MarshalJSON formats a stacktrace Frame for easy inclusion in JSON stack
+// traces. The format is the same as that of fmt.Format("%+v"), but without
+// newlines or tabs.
+func (f Frame) MarshalJSON() ([]byte, error) {
+	name := f.name()
+	if name == "unknown" {
+		return json.Marshal(name)
+	}
+	str := fmt.Sprintf("%s %s:%d", name, f.file(), f.line())
+	return json.Marshal(str)
 }
 
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).

--- a/stack.go
+++ b/stack.go
@@ -1,7 +1,6 @@
 package errors
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
@@ -84,16 +83,14 @@ func (f Frame) Format(s fmt.State, verb rune) {
 	}
 }
 
-// MarshalJSON formats a stacktrace Frame for easy inclusion in JSON stack
-// traces. The format is the same as that of fmt.Format("%+v"), but without
-// newlines or tabs.
-func (f Frame) MarshalJSON() ([]byte, error) {
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f Frame) MarshalText() ([]byte, error) {
 	name := f.name()
 	if name == "unknown" {
-		return json.Marshal(name)
+		return []byte(name), nil
 	}
-	str := fmt.Sprintf("%s %s:%d", name, f.file(), f.line())
-	return json.Marshal(str)
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
 }
 
 // StackTrace is stack of Frames from innermost (newest) to outermost (oldest).


### PR DESCRIPTION
Fixes #196

This PR adds `json.Marshaler` support for the `Frame` type, to facilitate logging of stack traces in JSON format.  The output format is equivalent to `fmt.Printf("v+%")`, but without newlines or tab characters.

To me, this format seems the most generally useful, but an argument could be made for outputting a JSON object instead (i.e. `{"file":"...", "line": XX, "name": "..."}`.).