### PR TITLE
travis.yml: add Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: go
 go_import_path: github.com/pkg/errors
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 script:


### PR DESCRIPTION
Also deprecate Go 1.9

Signed-off-by: Dave Cheney <dave@cheney.net>