### PR TITLE
fix `func Cause(error) error` returning nil on the root cause error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -282,7 +282,11 @@ func Cause(err error) error {
 		if !ok {
 			break
 		}
-		err = cause.Cause()
+		if cerr := cause.Cause(); cerr != nil {
+			err = cerr
+		} else {
+			break
+		}
 	}
 	return err
 }


### PR DESCRIPTION
Some error struct have `Cause() error` method indicating the cause of
the error, but that method could return nil indicating that that itself
is the root cause in the error chain

look at this struct
```go
type myError struct {
  message string
  cause   error
}

func (m *myError) Error() string { ... }

func (m *myError) Cause() error {
  return m.cause
}

func New(message string) error {
  return &myError{message: message}
}
```