### PR TITLE
feat: add go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pkg/errors
+
+go 1.13


### PR DESCRIPTION
Hi,  can i add go.mod file to the repo ？  

For the Ref:  https://golang.org/ref/mod#modules-overview
```
A module is identified by a module path, which is declared in a go.mod file...
```