### PR TITLE
[KH-13246] More Errors

### DIFF
--- a/error_access_denied.go
+++ b/error_access_denied.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorAccessDenied is returned when an action is attempted without sufficient permissions.
+type ErrorAccessDenied struct {
+	BaseError
+}
+
+// AccessDeniedf returns a new instance of ErrorAccessDenied.
+func AccessDeniedf(format string, a ...interface{}) error {
+	return ErrorAccessDenied{
+		NewBase("access denied :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_already_exists.go
+++ b/error_already_exists.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorAlreadyExists is returned when a new resource can't be created due to a conflict with an existing resource.
+type ErrorAlreadyExists struct {
+	BaseError
+}
+
+// AlreadyExists returns a new instance of ErrorAlreadyExists.
+func AlreadyExists(format string, a ...interface{}) error {
+	return ErrorAlreadyExists{
+		NewBase("already exists :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_bad_format.go
+++ b/error_bad_format.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorBadFormat is returned when data provided was in an incorrect format.
+type ErrorBadFormat struct {
+	BaseError
+}
+
+// BadFormat returns a new instance of ErrorBadFormat.
+func BadFormat(format string, a ...interface{}) error {
+	return ErrorBadFormat{
+		NewBase("bad format :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_conflicting_change.go
+++ b/error_conflicting_change.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorConflictingChange is returned when a change to a resource would conflict with an existing resource.
+type ErrorConflictingChange struct {
+	BaseError
+}
+
+// ConflictingChange returns a new instance of ErrorConflictingChange.
+func ConflictingChange(format string, a ...interface{}) error {
+	return ErrorConflictingChange{
+		NewBase("conflicting change :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_data_load.go
+++ b/error_data_load.go
@@ -12,6 +12,6 @@ type ErrorDataLoad struct {
 // DataLoad returns a new instance of ErrorDataLoad
 func DataLoad(message string) error {
 	return ErrorDataLoad{
-		new(fmt.Sprintf("data load failed :: %s", message)),
+		NewBase(fmt.Sprintf("data load failed :: %s", message)),
 	}
 }

--- a/error_data_load.go
+++ b/error_data_load.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorDataLoad is returned when database query failed
+type ErrorDataLoad struct {
+	BaseError
+}
+
+// DataLoad returns a new instance of ErrorDataLoad
+func DataLoad(message string) error {
+	return ErrorDataLoad{
+		new(fmt.Sprintf("data load failed :: %s", message)),
+	}
+}

--- a/error_disabled.go
+++ b/error_disabled.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorDisabled is returned when the action being attempted is disabled but not necessarily inherently to the user.
+type ErrorDisabled struct {
+	BaseError
+}
+
+// Disabled returns a new instance of ErrorDisabled.
+func Disabled(format string, a ...interface{}) error {
+	return ErrorDisabled{
+		NewBase("disabled :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_invalid_argument.go
+++ b/error_invalid_argument.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorInvalidArgument is returned when provided argument is not valid
+type ErrorInvalidArgument struct {
+	BaseError
+}
+
+// InvalidArgument returns a new instance of ErrorInvalidArgument
+func InvalidArgument(argument, reason string) error {
+	return ErrorInvalidArgument{
+		NewBase(fmt.Sprintf("invalid argument :: %s - %s", argument, reason)),
+	}
+}

--- a/error_io.go
+++ b/error_io.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorIO is returned when an I/O operation fails.
+type ErrorIO struct {
+	BaseError
+}
+
+// IO returns a new instance of ErrorIO.
+func IO(format string, a ...interface{}) error {
+	return ErrorAccessDenied{
+		NewBase("io operation failed :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_limited.go
+++ b/error_limited.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorLimited is returned when an action is attempted but has been temporarily limited (rate limited or otherwise).
+type ErrorLimited struct {
+	BaseError
+}
+
+// Limited returns a new instance of ErrorLimited.
+func Limited(format string, a ...interface{}) error {
+	return ErrorLimited{
+		NewBase("limited :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_network.go
+++ b/error_network.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorNetwork is returned when a network operation fails.
+type ErrorNetwork struct {
+	BaseError
+}
+
+// Network returns a new instance of ErrorNetwork.
+func Network(format string, a ...interface{}) error {
+	return ErrorNetwork{
+		NewBase("network operation failed :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_not_found.go
+++ b/error_not_found.go
@@ -12,6 +12,6 @@ type ErrorNotFound struct {
 // NotFound returns a new instance of ErrorNotFound
 func NotFound(message string) error {
 	return ErrorNotFound{
-		new(fmt.Sprintf("not found :: %s", message)),
+		NewBase(fmt.Sprintf("not found :: %s", message)),
 	}
 }

--- a/error_not_found.go
+++ b/error_not_found.go
@@ -1,0 +1,17 @@
+package errors
+
+import (
+	"fmt"
+)
+
+// ErrorNotFound is return when expected object is not present
+type ErrorNotFound struct {
+	BaseError
+}
+
+// NotFound returns a new instance of ErrorNotFound
+func NotFound(message string) error {
+	return ErrorNotFound{
+		new(fmt.Sprintf("not found :: %s", message)),
+	}
+}

--- a/error_uninitialized.go
+++ b/error_uninitialized.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorUninitialized is returned when a required dependency for this action has not been set up properly.
+type ErrorUninitialized struct {
+	BaseError
+}
+
+// Uninitialized returns a new instance of ErrorUninitialized.
+func Uninitialized(format string, a ...interface{}) error {
+	return ErrorUninitialized{
+		NewBase("uninitialized :: " + fmt.Sprintf(format, a...)),
+	}
+}

--- a/error_unsupported_type.go
+++ b/error_unsupported_type.go
@@ -10,6 +10,6 @@ type ErrorUnsupportedType struct {
 // UnsupportedType returns a new instance of ErrorUnsupportedType
 func UnsupportedType(message string) error {
 	return ErrorUnsupportedType{
-		new(fmt.Sprintf("unsupported type :: %s", message)),
+		NewBase(fmt.Sprintf("unsupported type :: %s", message)),
 	}
 }

--- a/error_unsupported_type.go
+++ b/error_unsupported_type.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+
+// ErrorUnsupportedType is returned when trying to process an unknown type
+type ErrorUnsupportedType struct {
+	BaseError
+}
+
+// UnsupportedType returns a new instance of ErrorUnsupportedType
+func UnsupportedType(message string) error {
+	return ErrorUnsupportedType{
+		new(fmt.Sprintf("unsupported type :: %s", message)),
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -116,7 +116,8 @@ func (e BaseError) Error() string {
 	return e.fundamental.Error()
 }
 
-func new(message string) BaseError {
+// NewBase returns an instance of BaseError
+func NewBase(message string) BaseError {
 	return BaseError{
 		&fundamental{
 			msg:   message,

--- a/json_test.go
+++ b/json_test.go
@@ -6,28 +6,6 @@ import (
 	"testing"
 )
 
-func TestFrameMarshalText(t *testing.T) {
-	var tests = []struct {
-		Frame
-		want string
-	}{{
-		initpc,
-		`^github.com/pkg/errors\.init(\.ializers)? .+/github\.com/pkg/errors/stack_test.go:\d+$`,
-	}, {
-		0,
-		`^unknown$`,
-	}}
-	for i, tt := range tests {
-		got, err := tt.Frame.MarshalText()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !regexp.MustCompile(tt.want).Match(got) {
-			t.Errorf("test %d: MarshalJSON:\n got %q\n want %q", i+1, string(got), tt.want)
-		}
-	}
-}
-
 func TestFrameMarshalJSON(t *testing.T) {
 	var tests = []struct {
 		Frame


### PR DESCRIPTION
Adding more errors to have better granularity. The structure and thought behind these additions is as follows:

# Data State Errors

### AlreadyExists [NEW]
The resource trying to be created already exists.

### ConflictingChanges [NEW]
Changes to a resource cannot be performed due to conflicts with other existing resources.

### NotFound
Resource is not found.

# Parameter Errors

### BadFormat [NEW]
Data provided is of the correct type but is in a format that could not be understood.

### InvalidArgument
Data provided was invalid.

## MissingAgrument [NEW]
Data was expected but is missing.

### UnsupportedType
Data has been provded in an unsupported type.

### Uninitialzied [NEW]
A dependency hasn’t been initialized but is required.

# General System Errors

### IO [NEW]
An I/O operation failed.

### DataLoad
Data could not be loaded.

### Network [NEW]
Network operation failed.

# Permission Errors

### AccessDenied [NEW]
Current context does not have permission to access this action.

### Disabled [NEW]
The action is disabled (feature flagging, etc) in a way that’s not necessarily specific to this context.

### Limited [NEW]
The action has been temporarily limited (rate limiting, etc) in a way that is not based off of the application state.