### PR TITLE
feat ExistStack: Add a public method to determine if the error has been appended to the stack.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -119,7 +119,7 @@ func ExistStack(err error) bool {
 		Cause() error
 	}
 	if value, ok := err.(causer); ok {
-		return ExistStack(err.Cause())
+		return ExistStack(value.Cause())
 	} else {
 		return false
 	}

--- a/errors.go
+++ b/errors.go
@@ -67,9 +67,10 @@
 //
 // New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
 // invoked. This information can be retrieved with the following interface:
-type stackTracer interface {
-        StackTrace() errors.StackTrace
-}
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
 //
 // The returned errors.StackTrace type is defined as
 //

--- a/errors.go
+++ b/errors.go
@@ -67,10 +67,9 @@
 //
 // New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
 // invoked. This information can be retrieved with the following interface:
-//
-//     type stackTracer interface {
-//             StackTrace() errors.StackTrace
-//     }
+type stackTracer interface {
+        StackTrace() errors.StackTrace
+}
 //
 // The returned errors.StackTrace type is defined as
 //
@@ -106,6 +105,23 @@ func New(message string) error {
 	}
 }
 
+// ExistStack return an error already with stack
+// ExistStack will check all parent error
+func ExistStack(err error) bool {
+	type stackTracer interface {
+		StackTrace() StackTrace
+	}
+	if _, ok := err.(stackTracer); ok {
+		return true
+	}
+	type causer interface {
+		Cause() error
+	}
+	if _, ok := err.(causer); !ok {
+		return false
+	}
+	return ExistStack(err.Cause())
+}
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.
 // Errorf also records the stack trace at the point it was called.

--- a/errors.go
+++ b/errors.go
@@ -123,6 +123,11 @@ func ExistStack(err error) bool {
 	} else {
 		return false
 	}
+	cause, ok := err.(causer)
+        if !ok {
+                return false
+        }
+        return ExistStack(cause.Cause())
 }
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.

--- a/errors.go
+++ b/errors.go
@@ -118,10 +118,11 @@ func ExistStack(err error) bool {
 	type causer interface {
 		Cause() error
 	}
-	if _, ok := err.(causer); !ok {
+	if value, ok := err.(causer); ok {
+		return ExistStack(err.Cause())
+	} else {
 		return false
 	}
-	return ExistStack(err.Cause())
 }
 // Errorf formats according to a format specifier and returns the string
 // as a value that satisfies error.

--- a/errors_test.go
+++ b/errors_test.go
@@ -27,6 +27,23 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestExistStack(t *testing.T) {
+	tests := []struct {
+		err  error
+		want bool
+	}{
+		{io.EOF, false},
+		{Wrap(io.EOF, "read error"), true},
+	}
+
+	for _, tt := range tests {
+		got := ExistStack(tt.err)
+		if got != tt.want {
+			t.Errorf("ExistStack(%v): got: %v, want %v", tt.err, got, tt.want)
+		}
+	}
+}
+
 func TestWrapNil(t *testing.T) {
 	got := Wrap(nil, "no error")
 	if got != nil {


### PR DESCRIPTION
non-intrusive:
Add a public method to determine if the error has been appended to the stack.
Avoid adding the stack repeatedly for errors.